### PR TITLE
Force vpc and eks module tests to use tested module default values

### DIFF
--- a/modules/aws/eks/test/variables.tf
+++ b/modules/aws/eks/test/variables.tf
@@ -8,93 +8,87 @@ variable "vpc_prefix" {
 
 variable "eks_cluster_version" {
   type    = string
-  default = "1.26"
+  default = null
 }
 
 variable "iam_admin_role" {
   type    = string
-  default = "AWSReservedSSO_AdministratorAccess_.*" #Sometimes "AWSReservedSSO_AWSAdministratorAccess_.*" ?
+  default = null
 }
 
 variable "eks_cluster_public" {
   type    = bool
-  default = false
+  default = null
 }
 
 variable "eks_main_min_size" {
   type    = number
-  default = 1
+  default = null
 }
 
 variable "eks_main_max_size" {
   type    = number
-  default = 3
+  default = null
 }
 
 variable "eks_main_instance_types" {
   type    = list(string)
-  default = ["t3.large"]
+  default = null
 }
 
 variable "eks_spot_min_size" {
   type    = number
-  default = 1
+  default = null
 }
 
 variable "eks_spot_max_size" {
   type    = number
-  default = 3
+  default = null
 }
 
 variable "eks_spot_instance_types" {
   type = list(string)
-  default = [
-    "t3.medium",
-    "t3.large"
-  ]
+  default = null
 }
 
 variable "eks_db_min_size" {
   type    = number
-  default = 1
+  default = null
 }
 
 variable "eks_db_max_size" {
   type    = number
-  default = 3
+  default = null
 }
 
 variable "eks_db_instance_types" {
   type    = list(string)
-  default = ["t3.large"]
+  default = null
 }
 
 
 variable "eks_monitoring_min_size" {
   type    = number
-  default = 1
+  default = null
 }
 
 variable "eks_monitoring_max_size" {
   type    = number
-  default = 3
+  default = null
 }
 
 variable "eks_monitoring_instance_types" {
   type    = list(string)
-  default = ["t3.large"]
+  default = null
 }
 
 variable "eks_monitoring_single_subnet" {
   type    = bool
-  default = true
+  default = null
 }
 
 variable "cluster_enabled_log_types" {
   type    = list(string)
-  default = ["api", "authenticator"]
+  default = null
 }
 
-locals {
-  hname = "${var.prefix}-${terraform.workspace}"
-}

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -8,26 +8,31 @@ variable "vpc_prefix" {
 
 variable "eks_cluster_version" {
   type    = string
+  nullable = false
   default = "1.26"
 }
 
 variable "iam_admin_role" {
   type    = string
+  nullable = false
   default = "AWSReservedSSO_AdministratorAccess_.*" #Sometimes "AWSReservedSSO_AWSAdministratorAccess_.*" ?
 }
 
 variable "eks_cluster_public" {
   type    = bool
+  nullable = false
   default = false
 }
 
 variable "eks_main_min_size" {
   type    = number
+  nullable = false
   default = 1
 }
 
 variable "eks_main_max_size" {
   type    = number
+  nullable = false
   default = 3
 }
 
@@ -38,16 +43,19 @@ variable "eks_main_instance_types" {
 
 variable "eks_spot_min_size" {
   type    = number
+  nullable = false
   default = 1
 }
 
 variable "eks_spot_max_size" {
   type    = number
+  nullable = false
   default = 3
 }
 
 variable "eks_spot_instance_types" {
   type = list(string)
+  nullable = false
   default = [
     "t3.medium",
     "t3.large"
@@ -56,27 +64,32 @@ variable "eks_spot_instance_types" {
 
 variable "eks_db_min_size" {
   type    = number
+  nullable = false
   default = 1
 }
 
 variable "eks_db_max_size" {
   type    = number
+  nullable = false
   default = 3
 }
 
 variable "eks_db_instance_types" {
   type    = list(string)
+  nullable = false
   default = ["t3.large"]
 }
 
 
 variable "eks_monitoring_min_size" {
   type    = number
+  nullable = false
   default = 1
 }
 
 variable "eks_monitoring_max_size" {
   type    = number
+  nullable = false
   default = 3
 }
 
@@ -87,11 +100,13 @@ variable "eks_monitoring_instance_types" {
 
 variable "eks_monitoring_single_subnet" {
   type    = bool
+  nullable = false
   default = true
 }
 
 variable "cluster_enabled_log_types" {
   type    = list(string)
+  nullable = false
   default = ["api", "authenticator"]
 }
 

--- a/modules/aws/vpc/test/tf_unit_basic_test_2.tfvars
+++ b/modules/aws/vpc/test/tf_unit_basic_test_2.tfvars
@@ -3,6 +3,4 @@ vpc_cidr = "10.146.0.0/16"
 one_nat_gateway_per_az = false
 private_subnets = ["10.146.32.0/21", "10.146.40.0/21", "10.146.48.0/21"]
 public_subnets = ["10.146.4.0/24", "10.146.5.0/24"]
-database_subnets = []
-elasticache_subnets = []
 intra_subnets = ["10.146.0.0/26"]

--- a/modules/aws/vpc/test/variables.tf
+++ b/modules/aws/vpc/test/variables.tf
@@ -8,29 +8,30 @@ variable "vpc_cidr" {
 
 variable "one_nat_gateway_per_az" {
   type = bool
-  default = false
+  default = null
 }
 
 variable "private_subnets" {
   type = list(string)
+  default = null
 }
 
 variable "public_subnets" {
   type = list(string)
+  default = null
 }
 
 variable "database_subnets" {
   type = list(string)
+  default = null
 }
 
 variable "elasticache_subnets" {
   type = list(string)
+  default = null
 }
 
 variable "intra_subnets" {
   type = list(string)
-}
-
-locals {
-  hname = "${var.prefix}-${terraform.workspace}"
+  default = null
 }

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -8,6 +8,7 @@ variable "vpc_cidr" {
 
 variable "one_nat_gateway_per_az" {
   type = bool
+  nullable = false
   default = false
 }
 
@@ -21,14 +22,20 @@ variable "public_subnets" {
 
 variable "database_subnets" {
   type = list(string)
+  nullable = false
+  default = []
 }
 
 variable "elasticache_subnets" {
   type = list(string)
+  nullable = false
+  default = []
 }
 
 variable "intra_subnets" {
   type = list(string)
+  nullable = false
+  default = []
 }
 
 locals {


### PR DESCRIPTION
Use default = null for variables in test context and nullable = false to force default values in module context.