### PR TITLE
Remove dns domains from istio ingress and gateway configuration

### DIFF
--- a/modules/k8s/istio-gateway/templates/gateway.yaml
+++ b/modules/k8s/istio-gateway/templates/gateway.yaml
@@ -7,12 +7,7 @@ spec:
     app: '{{ .Values.gateway.name }}'
   servers:
   - hosts:
-    - "{{ .Values.domain }}"
-    {{- if .Values.altdomain }}
-    {{- range $url := .Values.altdomain }}
-    - "{{ $url }}"
-    {{- end }}
-    {{- end }}
+    - "*"
     port:
       name: http
       number: 80

--- a/modules/k8s/istio-gateway/templates/ingress.yaml
+++ b/modules/k8s/istio-gateway/templates/ingress.yaml
@@ -14,35 +14,13 @@ metadata:
     alb.ingress.kubernetes.io/scheme: '{{ .Values.scheme }}'
     alb.ingress.kubernetes.io/group.name: '{{ .Values.groupName }}'
     alb.ingress.kubernetes.io/target-type: ip
-    external-dns.alpha.kubernetes.io/ttl: "60"
     alb.ingress.kubernetes.io/tags: "{{ .Values.tags }}"
     kube-score/ignore: ingress-targets-service
     alb.ingress.kubernetes.io/group.order: "{{ .Values.groupOrder }}"
-    # kubernetes.io/ingress.class: alb
 spec:
   ingressClassName: alb
-  rules:
-  - host: "{{ .Values.domain }}"
-    http:
-      paths:
-      - backend:
-          service:
-            name: "{{ .Values.gateway.name }}"
-            port:
-              name: http2
-        path: /*
-        pathType: ImplementationSpecific
-  {{- if .Values.altdomain }}
-  {{- range $url := .Values.altdomain }}
-  - host: "{{ $url }}"
-    http:
-      paths:
-      - backend:
-          service:
-            name: "{{ $.Values.gateway.name }}"
-            port:
-              name: http2
-        path: /*
-        pathType: ImplementationSpecific
-  {{- end }}
-  {{- end }}
+  defaultBackend:
+    service:
+      name: "{{ .Values.gateway.name }}"
+      port:
+        name: http2

--- a/modules/k8s/istio-gateway/test/k8s_unit_basic_test.go
+++ b/modules/k8s/istio-gateway/test/k8s_unit_basic_test.go
@@ -14,14 +14,14 @@ import (
 )
 
 func TestK8sIstioGatewayBiz(t *testing.T) {
-	testK8sIstioGateway(t, "arn:aws:eks:eu-north-1:877483565445:cluster/runner-main-biz", "./k8s_unit_basic_test_biz.yaml", "runner-main-biz.infralib.entigo.io")
+	testK8sIstioGateway(t, "arn:aws:eks:eu-north-1:877483565445:cluster/runner-main-biz", "./k8s_unit_basic_test_biz.yaml")
 }
 
 func TestK8sIstioGatewayPri(t *testing.T) {
-	testK8sIstioGateway(t, "arn:aws:eks:eu-north-1:877483565445:cluster/runner-main-pri", "./k8s_unit_basic_test_pri.yaml", "runner-main-pri.infralib.entigo.io")
+	testK8sIstioGateway(t, "arn:aws:eks:eu-north-1:877483565445:cluster/runner-main-pri", "./k8s_unit_basic_test_pri.yaml")
 }
 
-func testK8sIstioGateway(t *testing.T, contextName string, valuesFile string, hostName string) {
+func testK8sIstioGateway(t *testing.T, contextName string, valuesFile string) {
 	t.Parallel()
 	spew.Dump("")
 
@@ -37,9 +37,6 @@ func testK8sIstioGateway(t *testing.T, contextName string, valuesFile string, ho
 		namespaceName = fmt.Sprintf("istio-gateway-%s", prefix)
 		extraArgs["upgrade"] = []string{"--skip-crds"}
 		extraArgs["install"] = []string{"--skip-crds"}
-		
-		setValues["domain"] = fmt.Sprintf("%s.%s", namespaceName, hostName)
-		setValues["altdomain[0]"] = fmt.Sprintf("more-%s.%s", namespaceName, hostName)
 	}
 	releaseName := namespaceName
 


### PR DESCRIPTION
Remove DNS info from istio gateway and corresponding ingress so external-dns does no take early ownership of those domains.