### PR TITLE
Set alb as default ingressClass

### DIFF
--- a/modules/k8s/aws-alb/values.yaml
+++ b/modules/k8s/aws-alb/values.yaml
@@ -33,6 +33,8 @@ aws-load-balancer-controller:
       cpu: 10m
       memory: 64Mi
       ephemeral-storage: 1Gi
+  ingressClassConfig:
+    default: true
   
   deploymentAnnotations:
     kube-score/ignore: pod-networkpolicy,pod-probes


### PR DESCRIPTION
Often the ingresses do not specify neither ingressClassName nor kubernetes.io/ingress.class, set alb ingressclass as default.