### PR TITLE
EC2 module - replaced user_data with user_data_base64

### DIFF
--- a/modules/aws/ec2/README.md
+++ b/modules/aws/ec2/README.md
@@ -28,6 +28,8 @@ __route53_name__ If not set prefix will be used for the DNS name of the ec2 inst
 
 __user_data__ run commands on instance creation
 
+__user_data_base64__ run commands on instance creation. Also supports gzipped and base64 encoded data
+
 __security_group_egress__ at the moment only support CIDR blocks
 ```
   default = {

--- a/modules/aws/ec2/main.tf
+++ b/modules/aws/ec2/main.tf
@@ -55,7 +55,7 @@ resource "aws_instance" "ec2" {
   ami           = data.aws_ami.ec2.id
   instance_type = var.instance_type
   subnet_id = var.subnet_id
-  user_data = var.user_data
+  user_data_base64 = var.user_data_base64 != "" ? var.user_data_base64 : base64encode(var.user_data)
   vpc_security_group_ids = [aws_security_group.ec2.id]
   associate_public_ip_address = var.eip || var.public_ip_address ? true : false
   key_name = var.key_name

--- a/modules/aws/ec2/variables.tf
+++ b/modules/aws/ec2/variables.tf
@@ -72,6 +72,11 @@ variable "user_data" {
   default = ""
 }
 
+variable "user_data_base64" {
+  type = string
+  default = ""
+}
+
 variable "security_group_egress" {
   type = map(object({
     from_port = number


### PR DESCRIPTION
user_data_base64 also supports gzip for long scripts. Existing user_data inputs stay the same, it will just get b64 encoded. EC2 instances will get restarts with this change!