### PR TITLE
AWS NG - added use_custom_launch_template

### DIFF
--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -15,6 +15,7 @@ module "eks-managed-node-group" {
   vpc_security_group_ids            = [var.node_security_group_id]
   
   pre_bootstrap_user_data = var.pre_bootstrap_user_data
+  use_custom_launch_template = length(var.remote_access) != 0 ? false : true
   remote_access = var.remote_access
   
   min_size     = var.min_size


### PR DESCRIPTION
In order to use remote_access block, it is needed to use EKS managed node group default launch template(not custom, which is enabled by default)