### PR TITLE
AWS NG replaced "node_security_group_id" with "security_group_ids"

### DIFF
--- a/modules/aws/eks-node-group/agent_input.yaml
+++ b/modules/aws/eks-node-group/agent_input.yaml
@@ -5,5 +5,6 @@ subnets: |
 
 cluster_primary_security_group_id: "{{ .toutput.eks.cluster_primary_security_group_id }}"
 cluster_service_cidr: "{{ .toutput.eks.cluster_service_cidr }}"
-node_security_group_id: "{{ .toutput.eks.node_security_group_id }}"
+security_group_ids: |
+  [{{ .toutput.eks.node_security_group_id }}]
 encryption_kms_key_arn: "{{ .toptout.kms.data_alias_arn }}"

--- a/modules/aws/eks-node-group/agent_input.yaml
+++ b/modules/aws/eks-node-group/agent_input.yaml
@@ -6,5 +6,5 @@ subnets: |
 cluster_primary_security_group_id: "{{ .toutput.eks.cluster_primary_security_group_id }}"
 cluster_service_cidr: "{{ .toutput.eks.cluster_service_cidr }}"
 security_group_ids: |
-  [{{ .toutput.eks.node_security_group_id }}]
+  ["{{ .toutput.eks.node_security_group_id }}"]
 encryption_kms_key_arn: "{{ .toptout.kms.data_alias_arn }}"

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -12,7 +12,7 @@ module "eks-managed-node-group" {
   subnet_ids              = var.subnets
   cluster_primary_security_group_id = var.cluster_primary_security_group_id
   cluster_service_cidr    = var.cluster_service_cidr
-  vpc_security_group_ids            = [var.node_security_group_id]
+  vpc_security_group_ids = var.security_group_ids
   
   pre_bootstrap_user_data = var.pre_bootstrap_user_data
   use_custom_launch_template = length(var.remote_access) != 0 ? false : true

--- a/modules/aws/eks-node-group/variables.tf
+++ b/modules/aws/eks-node-group/variables.tf
@@ -29,10 +29,8 @@ variable "cluster_service_cidr" {
   default     = ""
 }
 
-variable "node_security_group_id" {
-  type     = string
-  nullable = false
-  default  = ""
+variable "security_group_ids" {
+  type = list(string)
 }
 
 variable "min_size" {

--- a/modules/aws/eks-node-group/variables.tf
+++ b/modules/aws/eks-node-group/variables.tf
@@ -31,6 +31,7 @@ variable "cluster_service_cidr" {
 
 variable "security_group_ids" {
   type = list(string)
+  default = []
 }
 
 variable "min_size" {


### PR DESCRIPTION
In order to add multiple SGs if needed