### PR TITLE
field message removed from required in conditions of pginstance.

### DIFF
--- a/modules/k8s/entigo-portal-agent/templates/cp/pginstance-xrd.yaml
+++ b/modules/k8s/entigo-portal-agent/templates/cp/pginstance-xrd.yaml
@@ -122,7 +122,6 @@ spec:
                         type: string
                     required:
                       - lastTransitionTime
-                      - message
                       - reason
                       - status
                       - type


### PR DESCRIPTION
Removed "message" field from required fields.
Sync condition doesn't have any message, if no any issues.
Therefore our syncer can not sync status of pginstance and throws error, that required field message is missing.