### PR TITLE
chore(deps): update AWS Terraform provider

### DIFF
--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
     google = {
       source = "hashicorp/google"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
     google = {
       source = "hashicorp/google"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
     google = {
       source = "hashicorp/google"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
     google = {
       source = "hashicorp/google"

--- a/modules/aws-v2/route53/versions.tf
+++ b/modules/aws-v2/route53/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 } 

--- a/modules/aws-v2/route53/versions.tf
+++ b/modules/aws-v2/route53/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 } 

--- a/modules/aws-v2/route53/versions.tf
+++ b/modules/aws-v2/route53/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 } 

--- a/modules/aws-v2/route53/versions.tf
+++ b/modules/aws-v2/route53/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 } 

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 }

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 }

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 }

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 }

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.17.1"
+  version = "21.18.0"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.15.1"
+  version = "21.17.0"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.17.0"
+  version = "21.17.1"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.15.1"
+  version = "21.17.0"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.17.1"
+  version = "21.18.0"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -198,7 +198,7 @@ resource "aws_ec2_tag" "publicsubnets" {
 
 module "ebs_csi_irsa_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.4.0"
+  version               = "6.5.0"
   name                  = "${var.prefix}-ebs-csi"
   attach_ebs_csi_policy = true
   ebs_csi_kms_cmk_arns  = var.node_encryption_kms_key_arn != "" ? [var.node_encryption_kms_key_arn] : []
@@ -221,7 +221,7 @@ module "ebs_csi_irsa_role" {
 module "efs_csi_irsa_role" {
   count                 = var.enable_efs_csi ? 1 : 0
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.4.0"
+  version               = "6.5.0"
   name                  = "${var.prefix}-efs-csi"
   attach_efs_csi_policy = true
   oidc_providers = {
@@ -242,7 +242,7 @@ module "efs_csi_irsa_role" {
 
 module "vpc_cni_irsa_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.4.0"
+  version               = "6.5.0"
   name                  = "VPC-CNI-IRSA"
   attach_vpc_cni_policy = true
   vpc_cni_enable_ipv4   = true

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.17.0"
+  version = "21.17.1"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -198,7 +198,7 @@ resource "aws_ec2_tag" "publicsubnets" {
 
 module "ebs_csi_irsa_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.5.0"
+  version               = "6.6.0"
   name                  = "${var.prefix}-ebs-csi"
   attach_ebs_csi_policy = true
   ebs_csi_kms_cmk_arns  = var.node_encryption_kms_key_arn != "" ? [var.node_encryption_kms_key_arn] : []
@@ -221,7 +221,7 @@ module "ebs_csi_irsa_role" {
 module "efs_csi_irsa_role" {
   count                 = var.enable_efs_csi ? 1 : 0
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.5.0"
+  version               = "6.6.0"
   name                  = "${var.prefix}-efs-csi"
   attach_efs_csi_policy = true
   oidc_providers = {
@@ -242,7 +242,7 @@ module "efs_csi_irsa_role" {
 
 module "vpc_cni_irsa_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.5.0"
+  version               = "6.6.0"
   name                  = "VPC-CNI-IRSA"
   attach_vpc_cni_policy = true
   vpc_cni_enable_ipv4   = true

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 }

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 } 

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 } 

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 } 

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 } 

--- a/modules/aws/vpc/endpoints.tf
+++ b/modules/aws/vpc/endpoints.tf
@@ -1,7 +1,7 @@
 module "vpc_endpoints" {
   count = var.create_endpoint_ecr || var.create_gateway_s3 || var.create_endpoint_s3 ? 1 : 0
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "6.6.0"
+  version = "6.6.1"
   
   vpc_id = module.vpc.vpc_id
   subnet_ids = var.subnet_split_mode == "default" ? module.vpc.private_subnets : [for i in range(local.azs) : module.vpc.private_subnets[i+(2*local.azs)]]

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -50,7 +50,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "6.6.0"
+  version = "6.6.1"
 
   name = var.prefix
   cidr = var.vpc_cidr

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.42.0"
+      version = "6.43.0"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.38.0"
+      version = "6.39.0"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.39.0"
+      version = "6.41.0"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.41.0"
+      version = "6.42.0"
     }
   }
 }


### PR DESCRIPTION
## Version Updates

| Component | Old Version | New Version |
|-----------|------------|-------------|
| hashicorp/aws | 6.38.0 | 6.43.0 |
| terraform-aws-modules/eks/aws | 21.15.1 | 21.19.0 |
| terraform-aws-modules/iam/aws | 6.4.0 | 6.6.0 |
| terraform-aws-modules/vpc/aws | 6.6.0 | 6.6.1 |

**Files changed:** `modules/aws/*/versions.tf`, `modules/aws/eks/main.tf`, `modules/aws/vpc/main.tf`, `images/test/cache/main.tf`

## Release Notes (hashicorp/aws v6.43.0)

**New features:**
- New Data Sources: `aws_securityhub_enabled_standards`, `aws_securityhub_security_controls`
- New List Resources: `aws_db_subnet_group`, `aws_ec2_network_insights_access_scope`, `aws_iam_group_policy_attachment`, `aws_lambda_event_source_mapping`, `aws_securityhub_insight`
- New Resources: `aws_arczonalshift_autoshift_observer_notification_status`, `aws_ec2_network_insights_access_scope`, `aws_securityhub_account_v2`

**Full changelog:** https://github.com/hashicorp/terraform-provider-aws/releases