### PR TITLE
chore(deps): update Google Terraform providers

### DIFF
--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.25.0"
+      version = "7.26.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.29.0"
+      version = "7.30.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.28.0"
+      version = "7.29.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.26.0"
+      version = "7.28.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.28.0"
+      version = "7.29.0"
     }
   }
 }

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.29.0"
+      version = "7.30.0"
     }
   }
 }

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.26.0"
+      version = "7.28.0"
     }
   }
 }

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.25.0"
+      version = "7.26.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.28.0"
+      version = "7.29.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.29.0"
+      version = "7.30.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.26.0"
+      version = "7.28.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.25.0"
+      version = "7.26.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.28.0"
+      version = "7.29.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.29.0"
+      version = "7.30.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.26.0"
+      version = "7.28.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.25.0"
+      version = "7.26.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.26.0"
+      version = "7.28.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.28.0"
+      version = "7.29.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.29.0"
+      version = "7.30.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.25.0"
+      version = "7.26.0"
     }
   }
 }

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.25.0"
+      version = "7.26.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.29.0"
+      version = "7.30.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.28.0"
+      version = "7.29.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.26.0"
+      version = "7.28.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.28.0"
+      version = "7.29.0"
     }
   }
 }

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.29.0"
+      version = "7.30.0"
     }
   }
 }

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.26.0"
+      version = "7.28.0"
     }
   }
 }

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.25.0"
+      version = "7.26.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.28.0"
+      version = "7.29.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.28.0"
+      version = "7.29.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.26.0"
+      version = "7.28.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.26.0"
+      version = "7.28.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.25.0"
+      version = "7.26.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.25.0"
+      version = "7.26.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.29.0"
+      version = "7.30.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.29.0"
+      version = "7.30.0"
     }
   }
 }

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.25.0"
+      version = "7.26.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.29.0"
+      version = "7.30.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.28.0"
+      version = "7.29.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.26.0"
+      version = "7.28.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Version Updates

| Provider | Old Version | New Version |
|----------|------------|-------------|
| hashicorp/google | 7.25.0 | 7.30.0 |
| hashicorp/google-beta | 7.25.0 | 7.30.0 |

**Files changed:** `modules/google/*/versions.tf`, `images/test/cache/main.tf`

## Release Notes (v7.30.0)

⚠️ **Breaking Changes:**
- `google_apigee_env_keystore`: `name` field is now required (was previously optional but mandatory in Apigee API)

**New features:**
- New Data Source: `google_data_lineage_config`
- New Resources: `google_artifact_registry_rule`, `google_data_lineage_config`, `google_document_ai_schema`, `google_firebase_remote_config_remote_config`
- Provider: Added support for `prefer_global_endpoints` and `prefer_regional_endpoints` with regional endpoint rollout per product

**Full changelog:**
- https://github.com/hashicorp/terraform-provider-google/releases
- https://github.com/hashicorp/terraform-provider-google-beta/releases