### PR TITLE
chore(deps): update crossplane-contrib/provider-kafka v1.1.0 → v1.2.0

### DIFF
--- a/modules/k8s/crossplane-kafka/pullpush.sh
+++ b/modules/k8s/crossplane-kafka/pullpush.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" == "" ]; then
-    VERSION="v1.1.0"
+    VERSION="v1.2.0"
     echo "Defaulting to version $VERSION"
 else
     VERSION=$1

--- a/modules/k8s/crossplane-kafka/templates/aws/provider.yaml
+++ b/modules/k8s/crossplane-kafka/templates/aws/provider.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-kafka:v1.1.0
+  package: xpkg.upbound.io/crossplane-contrib/provider-kafka:v1.2.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig


### PR DESCRIPTION
## Version Update

| Provider | Old Version | New Version | File |
|----------|-------------|-------------|------|
| crossplane-contrib/provider-kafka | v1.1.0 | v1.2.0 | modules/k8s/crossplane-kafka/templates/aws/provider.yaml |

## Release Notes

[GitHub Releases](https://github.com/crossplane-contrib/provider-kafka/releases)

App version: v1.2.0. Key changes:
- **Feature**: Mount TLS certificates from a file
- **Feature**: Permanent client between reconcile loops (performance improvement)
- **Feature**: Add missing client TLS options
- **Feature**: Add support for role chain assumption

No breaking changes.

[Full Changelog](https://github.com/crossplane-contrib/provider-kafka/compare/v1.1.0...v1.2.0)