### PR TITLE
Fix inifinite loop in crossplane S3 due to missing blockedEncryptionT…

### DIFF
--- a/modules/k8s/loki/templates/aws/s3.yaml
+++ b/modules/k8s/loki/templates/aws/s3.yaml
@@ -136,6 +136,8 @@ spec:
             sseAlgorithm: AES256
           {{- end }}
         bucketKeyEnabled: true
+        blockedEncryptionTypes:
+          - SSE-C
     bucketRef:
       name: {{ .Values.global.bucketName }}
   providerConfigRef:

--- a/modules/k8s/mimir/templates/aws/s3.yaml
+++ b/modules/k8s/mimir/templates/aws/s3.yaml
@@ -96,6 +96,8 @@ spec:
             sseAlgorithm: AES256
           {{- end }}
         bucketKeyEnabled: true
+        blockedEncryptionTypes:
+          - SSE-C
     bucketRef:
       name: {{ .Values.global.bucketName }}
   providerConfigRef:


### PR DESCRIPTION
…ypes

In Crossplane AWS provider 2.5.3 the S3 provider goes into infinite loop if the fields are not defined.

https://github.com/crossplane-contrib/provider-upjet-aws/issues/2063