### PR TITLE
chore(deps): update AWS Terraform provider

### DIFF
--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
     google = {
       source = "hashicorp/google"

--- a/modules/aws-v2/route53/versions.tf
+++ b/modules/aws-v2/route53/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 } 

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 }

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.19.0"
+  version = "21.20.0"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.18.0"
+  version = "21.19.0"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.18.0"
+  version = "21.19.0"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.19.0"
+  version = "21.20.0"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 }

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 } 

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.43.0"
+      version = "6.44.0"
     }
   }
 }


### PR DESCRIPTION
## Version Updates

| Component | Old Version | New Version |
|-----------|-------------|-------------|
| hashicorp/aws | 6.43.0 | 6.44.0 |
| terraform-aws-modules/eks/aws | 21.18.0 | 21.20.0 |

## Release Notes

### hashicorp/aws v6.44.0
[GitHub Releases](https://github.com/hashicorp/terraform-provider-aws/releases)

**New in v6.44.0:**
- `aws_dynamodb_global_secondary_index` is no longer experimental — now subject to backwards compatibility guarantee
- New Data Source: `aws_glue_catalog`
- New List Resources: `aws_alb_target_group_attachment`, `aws_appautoscaling_policy`, `aws_dynamodb_global_secondary_index`, `aws_dynamodb_table`, `aws_ecr_repository_policy`

No breaking changes noted.

### terraform-aws-modules/eks/aws
[GitHub Releases](https://github.com/terraform-aws-modules/terraform-aws-eks/releases)

[Full Changelog](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.44.0)