### PR TITLE
chore(deps): update Google Terraform providers

### DIFF
--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.30.0"
+      version = "7.31.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.30.0"
+      version = "7.31.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.30.0"
+      version = "7.31.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.30.0"
+      version = "7.31.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.30.0"
+      version = "7.31.0"
     }
   }
 }

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.30.0"
+      version = "7.31.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.30.0"
+      version = "7.31.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.30.0"
+      version = "7.31.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.30.0"
+      version = "7.31.0"
     }
   }
 }

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.30.0"
+      version = "7.31.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Version Update

| Provider | Old Version | New Version |
|----------|------------|------------|
| hashicorp/google | 7.30.0 | 7.31.0 |
| hashicorp/google-beta | 7.30.0 | 7.31.0 |

**Files updated:** modules/google/*/versions.tf, images/test/cache/main.tf

## Release Notes

**Tag:** v7.31.0

### Key Changes
- Multiple compute resources migrated to use direct HTTP rather than a client library (improved performance)
- New data source: `google_artifact_registry_file`

[Full changelog - hashicorp/google releases](https://github.com/hashicorp/terraform-provider-google/releases)
[Full changelog - hashicorp/google-beta releases](https://github.com/hashicorp/terraform-provider-google-beta/releases)