### PR TITLE
chore(deps): update crossplane-contrib/provider-kafka v1.2.1 → v1.2.2

### DIFF
--- a/modules/k8s/crossplane-kafka/pullpush.sh
+++ b/modules/k8s/crossplane-kafka/pullpush.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" == "" ]; then
-    VERSION="v1.2.1"
+    VERSION="v1.2.2"
     echo "Defaulting to version $VERSION"
 else
     VERSION=$1

--- a/modules/k8s/crossplane-kafka/templates/aws/provider.yaml
+++ b/modules/k8s/crossplane-kafka/templates/aws/provider.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-kafka:v1.2.1
+  package: xpkg.upbound.io/crossplane-contrib/provider-kafka:v1.2.2
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig


### PR DESCRIPTION
## Crossplane Provider Update: crossplane-contrib/provider-kafka

| Field | Value |
|-------|-------|
| Provider | crossplane-contrib/provider-kafka |
| File | modules/k8s/crossplane-kafka/templates/aws/provider.yaml |
| Previous version | v1.2.1 |
| New version | v1.2.2 |

## Release Notes

- [GitHub Releases](https://github.com/crossplane-contrib/provider-kafka/releases)
- [Full Changelog](https://github.com/crossplane-contrib/provider-kafka/compare/v1.2.1...v1.2.2)

This is a patch update. See the crossplane-contrib/provider-kafka repository for details.