### PR TITLE
chore(deps): update AWS Terraform ami

### DIFF
--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -1,10 +1,10 @@
 locals {
   ami_release_version = {
-     "AL2023_ARM_64_NVIDIA"       = "1.34.7-20260505"
-     "AL2023_ARM_64_STANDARD"     = "1.34.7-20260505"
-     "AL2023_x86_64_NEURON"       = "1.34.7-20260505"
-     "AL2023_x86_64_NVIDIA"       = "1.34.7-20260505"
-     "AL2023_x86_64_STANDARD"     = "1.34.7-20260505"
+     "AL2023_ARM_64_NVIDIA"       = "1.34.7-20260512"
+     "AL2023_ARM_64_STANDARD"     = "1.34.7-20260512"
+     "AL2023_x86_64_NEURON"       = "1.34.7-20260512"
+     "AL2023_x86_64_NVIDIA"       = "1.34.7-20260512"
+     "AL2023_x86_64_STANDARD"     = "1.34.7-20260512"
      "BOTTLEROCKET_ARM_64"        = "1.60.0-c1f9ba0c"
      "BOTTLEROCKET_ARM_64_FIPS"   = "1.60.0-c1f9ba0c"
      "BOTTLEROCKET_ARM_64_NVIDIA" = "1.60.0-c1f9ba0c"

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -7,11 +7,11 @@ locals {
   #}] : []
 
   ami_release_version = {
-     "AL2023_ARM_64_NVIDIA"       = "1.34.7-20260505"
-     "AL2023_ARM_64_STANDARD"     = "1.34.7-20260505"
-     "AL2023_x86_64_NEURON"       = "1.34.7-20260505"
-     "AL2023_x86_64_NVIDIA"       = "1.34.7-20260505"
-     "AL2023_x86_64_STANDARD"     = "1.34.7-20260505"
+     "AL2023_ARM_64_NVIDIA"       = "1.34.7-20260512"
+     "AL2023_ARM_64_STANDARD"     = "1.34.7-20260512"
+     "AL2023_x86_64_NEURON"       = "1.34.7-20260512"
+     "AL2023_x86_64_NVIDIA"       = "1.34.7-20260512"
+     "AL2023_x86_64_STANDARD"     = "1.34.7-20260512"
      "BOTTLEROCKET_ARM_64"        = "1.60.0-c1f9ba0c"
      "BOTTLEROCKET_ARM_64_FIPS"   = "1.60.0-c1f9ba0c"
      "BOTTLEROCKET_ARM_64_NVIDIA" = "1.60.0-c1f9ba0c"


### PR DESCRIPTION
## Version Updates

| AMI | Old Version | New Version |
|-----|-------------|-------------|
| EKS AL2023_* | 1.34.7-20260505 | 1.34.7-20260512 |

**Files changed:** `modules/aws/eks/main.tf`, `modules/aws/eks-node-group/main.tf`

## Release Notes

[EKS AMI Releases](https://github.com/awslabs/amazon-eks-ami/releases)

This is a weekly AMI patch update for Amazon EKS AL2023 nodes (Kubernetes 1.34). The version bump from 20260505 to 20260512 represents the weekly image refresh with latest OS patches and security updates.

[Full changelog](https://github.com/awslabs/amazon-eks-ami/releases)