### PR TITLE
Add custom tags for eks nodes for example cost tags

### DIFF
--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -69,14 +69,14 @@ module "eks-managed-node-group" {
   
   labels = var.labels
   taints = var.taints
-  launch_template_tags = {
-    Terraform = "true"
-    Prefix    = var.prefix
+  launch_template_tags = merge({
+    Terraform  = "true"
+    Prefix     = var.prefix
     created-by = "entigo-infralib"
-  }
-  tags = {
-    Terraform = "true"
-    Prefix    = var.prefix
+  }, var.tags)
+  tags = merge({
+    Terraform  = "true"
+    Prefix     = var.prefix
     created-by = "entigo-infralib"
-  }
+  }, var.tags)
 }

--- a/modules/aws/eks-node-group/test/biz.yaml
+++ b/modules/aws/eks-node-group/test/biz.yaml
@@ -4,3 +4,7 @@ max_size: 1
 capacity_type: "SPOT"
 volume_size: 30
 use_latest_ami_release_version: true
+tags: |
+  {
+    team = "entigo-team"
+  }

--- a/modules/aws/eks-node-group/variables.tf
+++ b/modules/aws/eks-node-group/variables.tf
@@ -138,3 +138,8 @@ variable "taints" {
   type        = any
   default     = {}
 }
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
What: Adds custom tag support to the eks-node-group module.

test/biz.yaml changes need to be moved away before merging.

Why: EC2 instances created by node groups had no user-configurable tags, making cost allocation by team impossible in AWS Cost Explorer.