### PR TITLE
chore(deps): update crossplane-google provider v2.5.3 → v2.5.4

### DIFF
--- a/modules/k8s/crossplane-google/pullpush.sh
+++ b/modules/k8s/crossplane-google/pullpush.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" == "" ]; then
-    VERSION="v2.5.3"
+    VERSION="v2.5.4"
     echo "Defaulting to version $VERSION"
 else
     VERSION=$1

--- a/modules/k8s/crossplane-google/templates/provider.yaml
+++ b/modules/k8s/crossplane-google/templates/provider.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/upbound/provider-family-gcp:v2.5.3
+  package: xpkg.upbound.io/upbound/provider-family-gcp:v2.5.4
   runtimeConfigRef:
     name: {{ .Release.Name }}-family
 
@@ -44,7 +44,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   skipDependencyResolution: true
-  package: xpkg.upbound.io/upbound/provider-gcp-{{ $provider }}:v2.5.3
+  package: xpkg.upbound.io/upbound/provider-gcp-{{ $provider }}:v2.5.4
   runtimeConfigRef:
     name: {{ $.Release.Name }}
 {{- end }}


### PR DESCRIPTION
## Version Changes

| Provider | Old Version | New Version | File |
|----------|------------|------------|------|
| upbound/provider-family-gcp | v2.5.3 | v2.5.4 | modules/k8s/crossplane-google/templates/provider.yaml |

## Release Notes

Patch version update to upbound/provider-family-gcp.

[All Releases](https://github.com/crossplane-contrib/provider-upjet-gcp/releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)