### PR TITLE
chore(deps): update crossplane-sql provider v0.14.0 → v0.15.0

### DIFF
--- a/modules/k8s/crossplane-sql/pullpush.sh
+++ b/modules/k8s/crossplane-sql/pullpush.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" == "" ]; then
-    VERSION="v0.14.0"
+    VERSION="v0.15.0"
     echo "Defaulting to version $VERSION"
 else
     VERSION=$1

--- a/modules/k8s/crossplane-sql/templates/provider.yaml
+++ b/modules/k8s/crossplane-sql/templates/provider.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-sql:v0.14.0
+  package: xpkg.upbound.io/crossplane-contrib/provider-sql:v0.15.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig


### PR DESCRIPTION
## Version Changes

| Provider | Old Version | New Version | File |
|----------|------------|------------|------|
| crossplane-contrib/provider-sql | v0.14.0 | v0.15.0 | modules/k8s/crossplane-sql/templates/provider.yaml |

## Release Notes

Minor version update to crossplane-contrib/provider-sql.

[All Releases](https://github.com/crossplane-contrib/provider-sql/releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)