### PR TITLE
chore(deps): update AWS Terraform provider

### DIFF
--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
     google = {
       source = "hashicorp/google"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
     google = {
       source = "hashicorp/google"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
     google = {
       source = "hashicorp/google"

--- a/modules/aws-v2/route53/versions.tf
+++ b/modules/aws-v2/route53/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 } 

--- a/modules/aws-v2/route53/versions.tf
+++ b/modules/aws-v2/route53/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 } 

--- a/modules/aws-v2/route53/versions.tf
+++ b/modules/aws-v2/route53/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 } 

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 }

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 }

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 }

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.20.0"
+  version = "21.22.0"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.22.0"
+  version = "21.23.0"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -198,7 +198,7 @@ resource "aws_ec2_tag" "publicsubnets" {
 
 module "ebs_csi_irsa_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.6.0"
+  version               = "6.6.1"
   name                  = "${var.prefix}-ebs-csi"
   attach_ebs_csi_policy = true
   ebs_csi_kms_cmk_arns  = var.node_encryption_kms_key_arn != "" ? [var.node_encryption_kms_key_arn] : []
@@ -221,7 +221,7 @@ module "ebs_csi_irsa_role" {
 module "efs_csi_irsa_role" {
   count                 = var.enable_efs_csi ? 1 : 0
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.6.0"
+  version               = "6.6.1"
   name                  = "${var.prefix}-efs-csi"
   attach_efs_csi_policy = true
   oidc_providers = {
@@ -242,7 +242,7 @@ module "efs_csi_irsa_role" {
 
 module "vpc_cni_irsa_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.6.0"
+  version               = "6.6.1"
   name                  = "VPC-CNI-IRSA"
   attach_vpc_cni_policy = true
   vpc_cni_enable_ipv4   = true
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.22.0"
+  version = "21.23.0"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.20.0"
+  version = "21.22.0"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 }

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 } 

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 } 

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 } 

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.49.0"
+      version = "6.50.0"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.46.0"
+      version = "6.47.0"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.47.0"
+      version = "6.49.0"
     }
   }
 }


### PR DESCRIPTION
## chore(deps): update AWS Terraform provider

### Changes
| Component | Old Version | New Version |
|-----------|-------------|-------------|
| hashicorp/aws | 6.46.0 | 6.50.0 |
| terraform-aws-modules/eks/aws | 21.20.0 | 21.23.0 |
| terraform-aws-modules/iam/aws | 6.6.0 | 6.6.1 |

### Release Notes (hashicorp/aws v6.50.0)
See full releases: https://github.com/hashicorp/terraform-provider-aws/releases

**Key changes (6.50.0):**
- New resources: aws_bedrockagentcore_policy, aws_cloudwatch_log_s3_table_integration_source, aws_ecs_daemon, aws_ecs_daemon_task_definition
- Various enhancements and bug fixes

No breaking changes noted.

[Full Changelog](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.50.0)