### PR TITLE
chore(deps): update Google Terraform providers

### DIFF
--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.34.0"
+      version = "7.35.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.33.0"
+      version = "7.34.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.35.0"
+      version = "7.36.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.34.0"
+      version = "7.35.0"
     }
   }
 }

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.33.0"
+      version = "7.34.0"
     }
   }
 }

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.35.0"
+      version = "7.36.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.34.0"
+      version = "7.35.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.33.0"
+      version = "7.34.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.35.0"
+      version = "7.36.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.34.0"
+      version = "7.35.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.33.0"
+      version = "7.34.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.35.0"
+      version = "7.36.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/main.tf
+++ b/modules/google/gke-node-pool/main.tf
@@ -20,7 +20,7 @@ locals {
 # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/main/modules/gke-node-pool
 module "gke_node_pool" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/gke-node-pool"
-  version = "44.1.0"
+  version = "44.2.0"
 
   name               = local.node_pool_name
   cluster            = var.cluster_name

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.34.0"
+      version = "7.35.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.35.0"
+      version = "7.36.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.33.0"
+      version = "7.34.0"
     }
   }
 }

--- a/modules/google/gke/main.tf
+++ b/modules/google/gke/main.tf
@@ -133,7 +133,7 @@ locals {
 # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/main/modules/private-cluster
 module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version = "44.1.0"
+  version = "44.2.0"
 
   project_id             = data.google_client_config.this.project
   name                   = var.prefix

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.35.0"
+      version = "7.36.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.33.0"
+      version = "7.34.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.34.0"
+      version = "7.35.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.34.0"
+      version = "7.35.0"
     }
   }
 }

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.33.0"
+      version = "7.34.0"
     }
   }
 }

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.35.0"
+      version = "7.36.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.33.0"
+      version = "7.34.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.33.0"
+      version = "7.34.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.34.0"
+      version = "7.35.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.34.0"
+      version = "7.35.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.35.0"
+      version = "7.36.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.35.0"
+      version = "7.36.0"
     }
   }
 }

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.35.0"
+      version = "7.36.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.33.0"
+      version = "7.34.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.34.0"
+      version = "7.35.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## chore(deps): update Google Terraform providers

### Changes
| Component | Old Version | New Version |
|-----------|-------------|-------------|
| hashicorp/google | 7.33.0 | 7.36.0 |
| hashicorp/google-beta | 7.33.0 | 7.36.0 |
| terraform-google-modules/kubernetes-engine/google | 44.1.0 | 44.2.0 |

### Release Notes (hashicorp/google v7.36.0)
See full releases: https://github.com/hashicorp/terraform-provider-google/releases

**Key changes (7.36.0):**
- New data sources: google_apigee_instance, google_oracle_database_goldengate_deployment_types
- New resources: google_apigee_datastore, google_discovery_engine_search_engine_iam_binding, google_license_manager_configuration, google_migration_center_import_job
- Various enhancements and bug fixes

No breaking changes noted.

**Release links:**
- https://github.com/hashicorp/terraform-provider-google/releases/tag/v7.36.0
- https://github.com/hashicorp/terraform-provider-google-beta/releases
- https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/releases