### PR TITLE
chore(deps): update upbound/provider-family-gcp v2.5.4 → v2.6.0

### DIFF
--- a/modules/k8s/crossplane-google/pullpush.sh
+++ b/modules/k8s/crossplane-google/pullpush.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" == "" ]; then
-    VERSION="v2.5.4"
+    VERSION="v2.6.0"
     echo "Defaulting to version $VERSION"
 else
     VERSION=$1

--- a/modules/k8s/crossplane-google/templates/provider.yaml
+++ b/modules/k8s/crossplane-google/templates/provider.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/resource-policy: keep
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/upbound/provider-family-gcp:v2.5.4
+  package: xpkg.upbound.io/upbound/provider-family-gcp:v2.6.0
   runtimeConfigRef:
     name: {{ .Release.Name }}-family
 
@@ -44,7 +44,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   skipDependencyResolution: true
-  package: xpkg.upbound.io/upbound/provider-gcp-{{ $provider }}:v2.5.4
+  package: xpkg.upbound.io/upbound/provider-gcp-{{ $provider }}:v2.6.0
   runtimeConfigRef:
     name: {{ $.Release.Name }}
 {{- end }}


### PR DESCRIPTION
## chore(deps): update upbound/provider-family-gcp v2.5.4 → v2.6.0

### Changes
| File | Old Version | New Version |
|------|-------------|-------------|
| modules/k8s/crossplane-google/templates/provider.yaml | v2.5.4 | v2.6.0 |
| modules/k8s/crossplane-google/pullpush.sh | v2.5.4 | v2.6.0 |

### Release Notes
See full releases: https://github.com/crossplane-contrib/provider-upjet-gcp/releases

Minor version update with new resource types and bug fixes.

[Full Changelog](https://github.com/crossplane-contrib/provider-upjet-gcp/releases)