### PR TITLE
chore(deps): update crossplane-contrib/provider-kafka v1.3.1 → v1.3.2

### DIFF
--- a/modules/k8s/crossplane-kafka/pullpush.sh
+++ b/modules/k8s/crossplane-kafka/pullpush.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" == "" ]; then
-    VERSION="v1.3.1"
+    VERSION="v1.3.2"
     echo "Defaulting to version $VERSION"
 else
     VERSION=$1

--- a/modules/k8s/crossplane-kafka/templates/aws/provider.yaml
+++ b/modules/k8s/crossplane-kafka/templates/aws/provider.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-kafka:v1.3.1
+  package: xpkg.upbound.io/crossplane-contrib/provider-kafka:v1.3.2
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig


### PR DESCRIPTION
## Changes
- **crossplane-contrib/provider-kafka**: `v1.3.1` → `v1.3.2`
- File: `modules/k8s/crossplane-kafka/templates/aws/provider.yaml`

## Release Notes
- [provider-kafka releases](https://github.com/crossplane-contrib/provider-kafka/releases)

Release notes unavailable via API. Please check the [full changelog](https://github.com/crossplane-contrib/provider-kafka/releases) for details.