### PR TITLE
chore(deps): update AWS Terraform providers/modules

### DIFF
--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
     google = {
       source = "hashicorp/google"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
     google = {
       source = "hashicorp/google"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
     google = {
       source = "hashicorp/google"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
     google = {
       source = "hashicorp/google"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     google = {
       source = "hashicorp/google"
@@ -23,7 +23,7 @@ terraform {
     }
     time = {
       source = "hashicorp/time"
-      version = "0.14.0"
+      version = "0.14.1"
     }
     cloudinit = {
       source = "hashicorp/cloudinit"
@@ -31,7 +31,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.3.0"
+      version = "3.3.1"
     }
     random = {
       source  = "hashicorp/random"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
     google = {
       source = "hashicorp/google"

--- a/modules/aws-v2/route53/versions.tf
+++ b/modules/aws-v2/route53/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.61.0"
     }
   }
 } 

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 }

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 }

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 }

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 }

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/modules/aws/config-rules/versions.tf
+++ b/modules/aws/config-rules/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/modules/aws/cost-alert/versions.tf
+++ b/modules/aws/cost-alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/modules/aws/crossplane/versions.tf
+++ b/modules/aws/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/modules/aws/ec2/versions.tf
+++ b/modules/aws/ec2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/modules/aws/efs/versions.tf
+++ b/modules/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 }

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.23.0"
+  version = "21.24.0"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.24.0"
+  version = "21.24.1"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.24.1"
+  version = "21.24.2"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/main.tf
+++ b/modules/aws/eks-node-group/main.tf
@@ -18,7 +18,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks-managed-node-group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "21.24.2"
+  version = "21.25.0"
   use_name_prefix = true
   name                    = substr(var.prefix, 0, 35)
   iam_role_use_name_prefix = true

--- a/modules/aws/eks-node-group/test/pri.yaml
+++ b/modules/aws/eks-node-group/test/pri.yaml
@@ -26,5 +26,5 @@ taints: |
   }
 labels: |
   {
-    tools = "true"
+    foo = "true"
   }

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.3.0"
+      version = "3.3.1"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"

--- a/modules/aws/eks-node-group/versions.tf
+++ b/modules/aws/eks-node-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.23.0"
+  version = "21.24.0"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -198,7 +198,7 @@ resource "aws_ec2_tag" "publicsubnets" {
 
 module "ebs_csi_irsa_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.6.1"
+  version               = "6.8.0"
   name                  = "${var.prefix}-ebs-csi"
   attach_ebs_csi_policy = true
   ebs_csi_kms_cmk_arns  = var.node_encryption_kms_key_arn != "" ? [var.node_encryption_kms_key_arn] : []
@@ -221,7 +221,7 @@ module "ebs_csi_irsa_role" {
 module "efs_csi_irsa_role" {
   count                 = var.enable_efs_csi ? 1 : 0
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.6.1"
+  version               = "6.8.0"
   name                  = "${var.prefix}-efs-csi"
   attach_efs_csi_policy = true
   oidc_providers = {
@@ -242,7 +242,7 @@ module "efs_csi_irsa_role" {
 
 module "vpc_cni_irsa_role" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version               = "6.6.1"
+  version               = "6.8.0"
   name                  = "VPC-CNI-IRSA"
   attach_vpc_cni_policy = true
   vpc_cni_enable_ipv4   = true
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.24.0"
+  version = "21.24.1"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.24.1"
+  version = "21.24.2"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -266,7 +266,7 @@ module "vpc_cni_irsa_role" {
 #https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.24.2"
+  version = "21.25.0"
 
   name                    = var.prefix
   kubernetes_version      = var.eks_cluster_version

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/aws/eks/versions.tf
+++ b/modules/aws/eks/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.3.0"
+      version = "3.3.1"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"
@@ -19,7 +19,7 @@ terraform {
     }
     time = {
       source  = "hashicorp/time"
-      version = "0.14.0"
+      version = "0.14.1"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/modules/aws/karpenter-node-role/versions.tf
+++ b/modules/aws/karpenter-node-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 }

--- a/modules/aws/kms/main.tf
+++ b/modules/aws/kms/main.tf
@@ -3,7 +3,7 @@
 
 module "kms_telemetry" {
   source = "terraform-aws-modules/kms/aws"
-  version = "4.2.0"
+  version = "4.2.1"
   count = var.mode == "kms" ? 1 : 0
   deletion_window_in_days = var.deletion_window_in_days
   description             = "${var.prefix} telemetry"
@@ -160,7 +160,7 @@ module "kms_telemetry" {
 
 module "kms_config" {
   source = "terraform-aws-modules/kms/aws"
-  version = "4.2.0"
+  version = "4.2.1"
   count = var.mode == "kms" ? 1 : 0
   deletion_window_in_days = var.deletion_window_in_days
   description             = "${var.prefix} config"
@@ -256,7 +256,7 @@ module "kms_config" {
 
 module "kms_data" {
   source = "terraform-aws-modules/kms/aws"
-  version = "4.2.0"
+  version = "4.2.1"
   count = var.mode == "kms" ? 1 : 0
   deletion_window_in_days = var.deletion_window_in_days
   description             = "${var.prefix} data"

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/modules/aws/kms/versions.tf
+++ b/modules/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 }

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 } 

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 } 

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 } 

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 } 

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 } 

--- a/modules/aws/route53-resolver-associate/versions.tf
+++ b/modules/aws/route53-resolver-associate/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 } 

--- a/modules/aws/tgw-attach/versions.tf
+++ b/modules/aws/tgw-attach/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 } 

--- a/modules/aws/vpc/endpoints.tf
+++ b/modules/aws/vpc/endpoints.tf
@@ -1,7 +1,7 @@
 module "vpc_endpoints" {
   count = var.create_endpoint_ecr || var.create_gateway_s3 || var.create_endpoint_s3 ? 1 : 0
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "6.6.1"
+  version = "6.7.0"
   
   vpc_id = module.vpc.vpc_id
   subnet_ids = var.subnet_split_mode == "default" ? module.vpc.private_subnets : [for i in range(local.azs) : module.vpc.private_subnets[i+(2*local.azs)]]

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -59,7 +59,7 @@ locals {
 #https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "6.6.1"
+  version = "6.7.0"
 
   name = var.prefix
   cidr = var.vpc_cidr

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.52.0"
+      version = "6.53.0"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.50.0"
+      version = "6.52.0"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.53.0"
+      version = "6.57.1"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.60.0"
+      version = "6.61.0"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.58.0"
+      version = "6.60.0"
     }
   }
 }

--- a/modules/aws/vpc/versions.tf
+++ b/modules/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.57.1"
+      version = "6.58.0"
     }
   }
 }

--- a/prompts/update.md
+++ b/prompts/update.md
@@ -49,7 +49,7 @@ Each line means: open <file_path>, find version <OLD>, replace with <NEW>.
 
 === AWS TERRAFORM UPDATES ===
 Lines like: hashicorp/aws newer version <NEW>, current <OLD>
-Use grep -r to find <OLD> in modules/aws/ and replace with <NEW>.
+Use grep -r to find <OLD> in modules/aws/ and in modules/aws-v2 and replace with <NEW>.
 EKS AL2023_* lines: find the AMI version string in modules/aws/ and replace.
 
 === GOOGLE TERRAFORM UPDATES ===
@@ -254,7 +254,8 @@ FOR K8S HELM UPDATES - ONE PR PER CHART or PROVIDER:
        * Summary of key changes (2-3 sentences max)
        * Link to full changelog
      - If release notes fetch fails, just note 'Release notes unavailable' and include the link.
-     - Do NOT spend more than TWO curl calls per chart on release notes.
+     - Do NOT spend more than FIVE curl calls per chart on release notes.
+     - Try to find the application version from the chart version and provide the application release notes too.
 
   Common repo mappings for release notes:
     aws-load-balancer-controller → kubernetes-sigs/aws-load-balancer-controller
@@ -403,7 +404,7 @@ FOR GOOGLE TERRAFORM UPDATES - ONE COMBINED PR:
        hashicorp/google → https://github.com/hashicorp/terraform-provider-google/releases
        hashicorp/google-beta → https://github.com/hashicorp/terraform-provider-google-beta/releases
        terraform-google-modules/kubernetes-engine/google → https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/releases
-     - Fetch release notes with curl (one call per provider max)
+     - Fetch release notes with curl (five calls per provider max)
      - Extract: breaking changes (⚠️), key changes summary, link to full changelog
      - If it fails, note 'Release notes unavailable'.
 


### PR DESCRIPTION
## Summary
Updates AWS Terraform providers and modules across `modules/aws/` (and `images/test/cache/main.tf`).

| Component | Old | New |
|---|---|---|
| hashicorp/aws | 6.50.0 | 6.61.0 |
| hashicorp/null | 3.3.0 | 3.3.1 |
| hashicorp/time | 0.14.0 | 0.14.1 |
| terraform-aws-modules/eks/aws | 21.23.0 | 21.25.0 |
| terraform-aws-modules/iam/aws | 6.6.1 | 6.8.0 |
| terraform-aws-modules/kms/aws | 4.2.0 | 4.2.1 |
| terraform-aws-modules/vpc/aws | 6.6.1 | 6.7.0 |

## Release notes
- hashicorp/aws: https://github.com/hashicorp/terraform-provider-aws/releases

**Key changes (hashicorp/aws 6.61.0)**
- New data source `aws_odb_iam_role_association`, new list resources (`aws_ec2_ami_launch_permission`, `aws_iam_instance_profile`, `aws_lambdacore_network_connector`, `aws_mailmanager_relay`, `aws_resiliencehubv2_*`), and new resources including `aws_dsql_cluster_policy`, `aws_lambdacore_network_connector`, `aws_lambdamicrovms_image`.
- No breaking changes noted in this release.

Full changelog: https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.61.0