### PR TITLE
chore(deps): update Google Terraform providers

### DIFF
--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.36.0"
+      version = "7.38.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.38.0"
+      version = "7.39.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.44.0"
+      version = "7.46.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.43.0"
+      version = "7.44.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.42.0"
+      version = "7.43.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -9,6 +9,10 @@ terraform {
       source = "hashicorp/google"
       version = "7.46.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "7.46.0"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "3.0.1"

--- a/images/test/cache/main.tf
+++ b/images/test/cache/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google = {
       source = "hashicorp/google"
-      version = "7.39.0"
+      version = "7.42.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.38.0"
+      version = "7.39.0"
     }
   }
 }

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.36.0"
+      version = "7.38.0"
     }
   }
 }

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.44.0"
+      version = "7.46.0"
     }
   }
 }

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.39.0"
+      version = "7.42.0"
     }
   }
 }

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.43.0"
+      version = "7.44.0"
     }
   }
 }

--- a/modules/google/crossplane/versions.tf
+++ b/modules/google/crossplane/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.42.0"
+      version = "7.43.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.38.0"
+      version = "7.39.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.36.0"
+      version = "7.38.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.44.0"
+      version = "7.46.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.39.0"
+      version = "7.42.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.43.0"
+      version = "7.44.0"
     }
   }
 }

--- a/modules/google/dns/versions.tf
+++ b/modules/google/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.42.0"
+      version = "7.43.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.38.0"
+      version = "7.39.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.36.0"
+      version = "7.38.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.44.0"
+      version = "7.46.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.39.0"
+      version = "7.42.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.43.0"
+      version = "7.44.0"
     }
   }
 }

--- a/modules/google/gar-proxy/versions.tf
+++ b/modules/google/gar-proxy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.42.0"
+      version = "7.43.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/main.tf
+++ b/modules/google/gke-node-pool/main.tf
@@ -20,7 +20,7 @@ locals {
 # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/main/modules/gke-node-pool
 module "gke_node_pool" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/gke-node-pool"
-  version = "44.2.0"
+  version = "44.3.0"
 
   name               = local.node_pool_name
   cluster            = var.cluster_name

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.36.0"
+      version = "7.38.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.38.0"
+      version = "7.39.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.44.0"
+      version = "7.45.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.39.0"
+      version = "7.42.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.45.0"
+      version = "7.46.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.43.0"
+      version = "7.44.0"
     }
   }
 }

--- a/modules/google/gke-node-pool/versions.tf
+++ b/modules/google/gke-node-pool/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.42.0"
+      version = "7.43.0"
     }
   }
 }

--- a/modules/google/gke/main.tf
+++ b/modules/google/gke/main.tf
@@ -149,7 +149,7 @@ locals {
 # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/main/modules/private-cluster
 module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version = "44.2.0"
+  version = "44.3.0"
 
   project_id             = data.google_client_config.this.project
   name                   = var.prefix

--- a/modules/google/gke/main.tf
+++ b/modules/google/gke/main.tf
@@ -133,7 +133,7 @@ locals {
 # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/main/modules/private-cluster
 module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version = "44.2.0"
+  version = "44.3.0"
 
   project_id             = data.google_client_config.this.project
   name                   = var.prefix

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.36.0"
+      version = "7.38.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.38.0"
+      version = "7.39.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.44.0"
+      version = "7.46.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.39.0"
+      version = "7.42.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.42.0"
+      version = "7.43.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/gke/versions.tf
+++ b/modules/google/gke/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.43.0"
+      version = "7.44.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.38.0"
+      version = "7.39.0"
     }
   }
 }

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.36.0"
+      version = "7.38.0"
     }
   }
 }

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.44.0"
+      version = "7.46.0"
     }
   }
 }

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.39.0"
+      version = "7.42.0"
     }
   }
 }

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.43.0"
+      version = "7.44.0"
     }
   }
 }

--- a/modules/google/kms/versions.tf
+++ b/modules/google/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.42.0"
+      version = "7.43.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.36.0"
+      version = "7.38.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.36.0"
+      version = "7.38.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.38.0"
+      version = "7.39.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.38.0"
+      version = "7.39.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.42.0"
+      version = "7.43.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.42.0"
+      version = "7.43.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.44.0"
+      version = "7.46.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.44.0"
+      version = "7.45.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.39.0"
+      version = "7.42.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.39.0"
+      version = "7.42.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.43.0"
+      version = "7.44.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.43.0"
+      version = "7.44.0"
     }
   }
 }

--- a/modules/google/services/versions.tf
+++ b/modules/google/services/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.45.0"
+      version = "7.46.0"
     }
   }
 }

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.36.0"
+      version = "7.38.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.38.0"
+      version = "7.39.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.44.0"
+      version = "7.46.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.39.0"
+      version = "7.42.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.42.0"
+      version = "7.43.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/google/vpc/versions.tf
+++ b/modules/google/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.43.0"
+      version = "7.44.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Summary
Updates Google Terraform providers and the GKE module across `modules/google/` (and `images/test/cache/main.tf`).

| Component | Old | New |
|---|---|---|
| hashicorp/google | 7.36.0 | 7.46.0 |
| hashicorp/google-beta | 7.36.0 | 7.46.0 |
| terraform-google-modules/kubernetes-engine/google | 44.2.0 | 44.3.0 |

## Release notes
- hashicorp/google: https://github.com/hashicorp/terraform-provider-google/releases
- hashicorp/google-beta: https://github.com/hashicorp/terraform-provider-google-beta/releases
- GKE module: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/releases

**Key changes (hashicorp/google 7.46.0)**
- ⚠️ Deprecated `google_beyondcorp_app_connection`, `google_beyondcorp_app_connector`, and `google_beyondcorp_app_gateway` resources/data sources; use `google_beyondcorp_security_gateway` and `google_beyondcorp_security_gateway_application` instead.
- New data sources `google_memorystore_acl_policy`, `google_redis_cluster_acl_policy`, and new list resources.

Full changelog: https://github.com/hashicorp/terraform-provider-google/releases/tag/v7.46.0