### PR TITLE
chore(deps): update crossplane-contrib/provider-sql v0.15.0 → v0.16.0

### DIFF
--- a/modules/k8s/crossplane-sql/pullpush.sh
+++ b/modules/k8s/crossplane-sql/pullpush.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" == "" ]; then
-    VERSION="v0.15.0"
+    VERSION="v0.16.0"
     echo "Defaulting to version $VERSION"
 else
     VERSION=$1

--- a/modules/k8s/crossplane-sql/templates/provider.yaml
+++ b/modules/k8s/crossplane-sql/templates/provider.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-sql:v0.15.0
+  package: xpkg.upbound.io/crossplane-contrib/provider-sql:v0.16.0
   runtimeConfigRef:
     apiVersion: pkg.crossplane.io/v1beta1
     kind: DeploymentRuntimeConfig


### PR DESCRIPTION
## Summary
- Updated `crossplane-contrib/provider-sql` Crossplane provider from `v0.15.0` → `v0.16.0` in `modules/k8s/crossplane-sql/templates/provider.yaml` (and `pullpush.sh`)

## Release notes
Latest tagged GitHub release with notes is v0.15.0 (v0.16.0 has no separate release notes available yet). No breaking changes noted in v0.15.0.

Key changes (v0.15.0): support for `defaultCharacterSet`/`defaultCollation`, optional database-contained users instead of instance-level, PG schema cascade delete, new `crossplane_managed_resource_*` state metrics, replaced archived `denisenkom/go-mssqldb` with `microsoft/go-mssqldb`.

Releases: https://github.com/crossplane-contrib/provider-sql/releases