### PR TITLE
Change to supported channel on GKE

### DIFF
--- a/modules/google/gke-node-pool/variables.tf
+++ b/modules/google/gke-node-pool/variables.tf
@@ -33,7 +33,7 @@ variable "auto_repair" {
 
 variable "auto_upgrade" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "min_size" {

--- a/modules/google/gke/main.tf
+++ b/modules/google/gke/main.tf
@@ -128,6 +128,22 @@ locals {
   ]
 
   gke_managed_node_groups = concat(local.gke_managed_node_groups_all, var.gke_managed_node_groups_extra)
+
+  # Quantize to the 1st of the current month so the value only changes
+  # once a month instead of producing a diff on every plan
+  exclusion_start = formatdate("YYYY-MM-01'T'00:00:00'Z'", timestamp())
+
+  # ~9 months forward (timeadd only takes h/m/s, no month unit)
+  exclusion_end = timeadd(local.exclusion_start, "6570h")
+
+  maintenance_exclusions = var.maintenance_exclusions != null ? var.maintenance_exclusions : [{
+    name            = "block-auto-upgrades"
+    start_time      = local.exclusion_start
+    end_time        = local.exclusion_end
+    exclusion_scope = "NO_MINOR_OR_NODE_UPGRADES"
+  }]
+
+
 }
 
 # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/main/modules/private-cluster
@@ -221,7 +237,7 @@ module "gke" {
 
   # Replaces the old auto_upgrade=false behavior
   # main.tf, inside module "gke"
-  maintenance_exclusions = var.maintenance_exclusions
+  maintenance_exclusions = local.maintenance_exclusions
 }
 
 resource "google_kms_crypto_key_iam_member" "boot_disk_kms_key_encrypter_decrypter" {

--- a/modules/google/gke/main.tf
+++ b/modules/google/gke/main.tf
@@ -76,7 +76,7 @@ locals {
       disk_type          = var.gke_main_volume_type
       image_type         = "COS_CONTAINERD"
       auto_repair        = true
-      auto_upgrade       = false
+      auto_upgrade       = true
       spot               = var.gke_main_spot_nodes
       boot_disk_kms_key  = var.boot_disk_kms_key
       max_surge          = var.gke_main_max_surge
@@ -97,7 +97,7 @@ locals {
       disk_type          = var.gke_mon_volume_type
       image_type         = "COS_CONTAINERD"
       auto_repair        = true
-      auto_upgrade       = false
+      auto_upgrade       = true
       spot               = var.gke_mon_spot_nodes
       boot_disk_kms_key  = var.boot_disk_kms_key
       max_surge          = var.gke_mon_max_surge
@@ -118,7 +118,7 @@ locals {
       disk_type          = var.gke_tools_volume_type
       image_type         = "COS_CONTAINERD"
       auto_repair        = true
-      auto_upgrade       = false
+      auto_upgrade       = true
       spot               = var.gke_tools_spot_nodes
       boot_disk_kms_key  = var.boot_disk_kms_key
       max_surge          = var.gke_tools_max_surge
@@ -138,7 +138,7 @@ module "gke" {
   project_id             = data.google_client_config.this.project
   name                   = var.prefix
   kubernetes_version     = local.latest_stable_version
-  release_channel        = "UNSPECIFIED" # in order to disable auto upgrade
+  release_channel        = "STABLE" # in order to disable auto upgrade
   region                 = data.google_client_config.this.region
   network                = var.network
   subnetwork             = var.subnetwork
@@ -218,6 +218,10 @@ module "gke" {
   }
 
   master_authorized_networks = var.master_authorized_networks
+
+  # Replaces the old auto_upgrade=false behavior
+  # main.tf, inside module "gke"
+  maintenance_exclusions = var.maintenance_exclusions
 }
 
 resource "google_kms_crypto_key_iam_member" "boot_disk_kms_key_encrypter_decrypter" {

--- a/modules/google/gke/main.tf
+++ b/modules/google/gke/main.tf
@@ -134,7 +134,7 @@ locals {
   exclusion_start = formatdate("YYYY-MM-01'T'00:00:00'Z'", timestamp())
 
   # ~9 months forward (timeadd only takes h/m/s, no month unit)
-  exclusion_end = timeadd(local.exclusion_start, "6570h")
+  exclusion_end = timeadd(local.exclusion_start, "1440h")
 
   maintenance_exclusions = var.maintenance_exclusions != null ? var.maintenance_exclusions : [{
     name            = "block-auto-upgrades"

--- a/modules/google/gke/variables.tf
+++ b/modules/google/gke/variables.tf
@@ -7,6 +7,22 @@ variable "kubernetes_version" {
   default = "1.35."
 }
 
+variable "maintenance_exclusions" {
+  type = list(object({
+    name            = string
+    start_time      = string
+    end_time        = string
+    exclusion_scope = string
+  }))
+  # end_time must stay before the running minor version's end-of-support date
+  default = [{
+    name            = "block-auto-upgrades"
+    start_time      = "2026-08-24T00:00:00Z"
+    end_time        = "2027-06-01T00:00:00Z"
+    exclusion_scope = "NO_MINOR_OR_NODE_UPGRADES"
+  }]
+}
+
 variable "preserve_kubernetes_version" {
   type        = bool
   default     = false

--- a/modules/google/gke/variables.tf
+++ b/modules/google/gke/variables.tf
@@ -14,13 +14,7 @@ variable "maintenance_exclusions" {
     end_time        = string
     exclusion_scope = string
   }))
-  # end_time must stay before the running minor version's end-of-support date
-  default = [{
-    name            = "block-auto-upgrades"
-    start_time      = "2026-08-24T00:00:00Z"
-    end_time        = "2027-06-01T00:00:00Z"
-    exclusion_scope = "NO_MINOR_OR_NODE_UPGRADES"
-  }]
+  default = null
 }
 
 variable "preserve_kubernetes_version" {


### PR DESCRIPTION
```This is a hard restriction on Google's side now: "No channel" (formerly Static) is deprecated — new customers can't create clusters with it, and it's removed entirely on June 14, 2027, after which remaining clusters get enrolled in Stable. Your project is treated as a "new customer", so the API rejects the create call. The fix is to explicitly set a release channel and pin versions via the channel instead.```


```Since you already pin everything to release_channel_latest_version["STABLE"], enroll in STABLE and replace the per-pool auto_upgrade = false with a maintenance exclusion, which is Google's recommended replacement: a cluster maintenance exclusion with scope "No minor or node upgrades" disables node auto-upgrades for all node pools on a channel-enrolled cluster.```