### PR TITLE
Fix ECR pull-through-cache secret race with time_sleep

### DIFF
--- a/modules/aws/ecr-proxy/main.tf
+++ b/modules/aws/ecr-proxy/main.tf
@@ -71,14 +71,26 @@ resource "aws_ecr_pull_through_cache_rule" "upstream_ecr" {
   custom_role_arn       =  aws_iam_role.ecrptc_service_role[0].arn
 }
 
+resource "time_sleep" "ecr_pullthroughcache_hub" {
+  count           = var.hub_username != "" && var.hub_token != "" ? 1 : 0
+  depends_on      = [aws_secretsmanager_secret_version.ecr_pullthroughcache_hub]
+  create_duration = "10s"
+}
+
 resource "aws_ecr_pull_through_cache_rule" "hub" {
   count = var.hub_username != "" && var.hub_token != "" ? 1 : 0
   ecr_repository_prefix = "${substr(var.prefix, 0, 24)}-hub"
   upstream_registry_url = "registry-1.docker.io"
   credential_arn        = aws_secretsmanager_secret.ecr_pullthroughcache_hub[0].arn
   depends_on = [
-    aws_secretsmanager_secret_version.ecr_pullthroughcache_hub
+    time_sleep.ecr_pullthroughcache_hub
   ]
+}
+
+resource "time_sleep" "ecr_pullthroughcache_ghcr" {
+  count           = var.ghcr_username != "" && var.ghcr_token != "" ? 1 : 0
+  depends_on      = [aws_secretsmanager_secret_version.ecr_pullthroughcache_ghcr]
+  create_duration = "10s"
 }
 
 resource "aws_ecr_pull_through_cache_rule" "ghcr" {
@@ -87,8 +99,14 @@ resource "aws_ecr_pull_through_cache_rule" "ghcr" {
   upstream_registry_url = "ghcr.io"
   credential_arn        = aws_secretsmanager_secret.ecr_pullthroughcache_ghcr[0].arn
   depends_on = [
-    aws_secretsmanager_secret_version.ecr_pullthroughcache_ghcr
+    time_sleep.ecr_pullthroughcache_ghcr
   ]
+}
+
+resource "time_sleep" "ecr_pullthroughcache_gcr" {
+  count           = var.gcr_username != "" && var.gcr_token != "" ? 1 : 0
+  depends_on      = [aws_secretsmanager_secret_version.ecr_pullthroughcache_gcr]
+  create_duration = "10s"
 }
 
 resource "aws_ecr_pull_through_cache_rule" "gcr" {
@@ -97,7 +115,7 @@ resource "aws_ecr_pull_through_cache_rule" "gcr" {
   upstream_registry_url = "gcr.io"
   credential_arn        = aws_secretsmanager_secret.ecr_pullthroughcache_gcr[0].arn
   depends_on = [
-    aws_secretsmanager_secret_version.ecr_pullthroughcache_gcr
+    time_sleep.ecr_pullthroughcache_gcr
   ]
 }
 

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "6.50.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "0.14.0"
+    }
   }
 }

--- a/modules/aws/ecr-proxy/versions.tf
+++ b/modules/aws/ecr-proxy/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     time = {
       source  = "hashicorp/time"
-      version = "0.14.0"
+      version = "0.14.1"
     }
   }
 }


### PR DESCRIPTION
## Summary
- `Agent Stable` runs on 2026-08-03, 08-21, and 08-26 failed the `pri-net` apply with `SecretNotFoundException: The ARN of the secret specified in the pull through cache rule was not found` when creating the ECR pull-through-cache rule for `hub`/`ghcr`.
- The `credential_arn` already has a `depends_on` on the corresponding `aws_secretsmanager_secret_version`, so Terraform is correctly ordering its own API calls — the failure is AWS-side eventual consistency: Secrets Manager returning success doesn't mean the secret is immediately resolvable by ECR's control plane when `CreatePullThroughCacheRule` validates it.
- Adds a `time_sleep` resource (10s) between each secret version and its cache rule for `hub`, `ghcr`, and `gcr`, giving the secret time to propagate before ECR references it. This mirrors the `hashicorp/time` provider already declared (at the same `0.14.0` version) in `modules/aws/eks`.

## Test plan
- [ ] `terraform validate` / `tofu validate` on `modules/aws/ecr-proxy`
- [ ] Run the `Agent Stable` workflow (or a manual `stable.sh tf` apply) a few times against a fresh AWS environment to confirm the `SecretNotFoundException` no longer occurs on `pri-net`
- [ ] If it still flakes, bump `create_duration` beyond 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)