### PR TITLE
Fix duplicated release notes in stable releases

### DIFF
--- a/.github/workflows/agent_release.yaml
+++ b/.github/workflows/agent_release.yaml
@@ -248,6 +248,7 @@ jobs:
         
         RELEASE_URL=$(gh release create ${{ steps.get_latest_release.outputs.new_version }} \
         --title "Release ${{ steps.get_latest_release.outputs.new_version }}" \
+        --notes-start-tag ${{ steps.get_latest_release.outputs.stable_version }} \
         --generate-notes \
         --notes "## Changed modules, providers and images
         $CHANGED


### PR DESCRIPTION
## Summary
- `gh release create --generate-notes` in `.github/workflows/agent_release.yaml` (the "Create Release" step) was called without `--notes-start-tag`, so GitHub auto-picks the "previous release" comparison baseline by recency across **all** tags in the repo — including the many unrelated component/module `-rc*` prereleases created by a separate pipeline and interleaved by date between stable `vX.Y.Z` releases.
- When one of those unrelated prereleases got picked as the baseline instead of the actual last stable release, the "What's Changed" diff window widened and re-listed PRs already shipped in an earlier stable release.
- Confirmed with real data: PR #1569 ("Fix OCI tofu packaging error") and PR #1563 (argo-cd bump) appear verbatim in the release notes of **four consecutive stable releases** (v1.22.6 → v1.22.9).
- Fix: pass `--notes-start-tag ${{ steps.get_latest_release.outputs.stable_version }}`, which the workflow already computes and uses elsewhere (e.g. for the "Changed modules" diff base) for exactly this purpose. This pins the comparison to the last stable release regardless of how many rc/component prereleases were tagged in between.
- The "Changed modules, providers and images" section is unaffected — it already diffs against `stable_version` via `tj-actions/changed-files`.

## Test plan
- [ ] Next scheduled run of `Agent Release` produces a stable release whose "What's Changed" section only lists PRs merged since the previous stable release (spot-check against `gh release view <new_tag>` vs `gh release view <previous_stable_tag>` for overlap)