### PR TITLE
Migrate k8s PR workflow to self-hosted arc-runner-set

### DIFF
--- a/.github/workflows/k8s_pull.yml
+++ b/.github/workflows/k8s_pull.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   detect:
     name: Detect changed modules
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       has_modules: ${{ steps.set-matrix.outputs.has_modules }}
@@ -55,7 +55,7 @@ jobs:
     name: Test ${{ matrix.module }}
     needs: detect
     if: needs.detect.outputs.has_modules == 'true'
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set
     # Remove concurrency group — turnstyle handles queuing without cancelling pending runs
     strategy:
       matrix: ${{ fromJson(needs.detect.outputs.matrix) }}

--- a/.github/workflows/k8s_pull.yml
+++ b/.github/workflows/k8s_pull.yml
@@ -75,6 +75,11 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION }}
       PR_BRANCH: ${{ github.event.pull_request.head.ref }}
       ENTIGO_INFRALIB_DESTROY: true
+      # arc-runner-set runs docker via a separate dind sidecar container that only shares
+      # the _work volume with this container, not $HOME. Point gcloud's config dir at the
+      # workspace so credentials written here are visible to `docker run -v $CLOUDSDK_CONFIG:...`
+      # on the dind side too.
+      CLOUDSDK_CONFIG: ${{ github.workspace }}/.gcloud-config
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/k8s_pull.yml
+++ b/.github/workflows/k8s_pull.yml
@@ -80,6 +80,8 @@ jobs:
       # workspace so credentials written here are visible to `docker run -v $CLOUDSDK_CONFIG:...`
       # on the dind side too.
       CLOUDSDK_CONFIG: ${{ github.workspace }}/.gcloud-config
+      # Same reasoning as CLOUDSDK_CONFIG above, for the kubeconfig directory.
+      KUBE_CONFIG_DIR: ${{ github.workspace }}/.kube-config
     steps:
     - uses: actions/checkout@v4
       with:

--- a/common/generate_config.sh
+++ b/common/generate_config.sh
@@ -45,6 +45,14 @@ google_auth_login() {
       fi
     done
     gcloud config set account $gaccount
+
+    # Newer Cloud SDK versions no longer write this file as a side effect of
+    # activate-service-account, but gsutil's legacy boto-based auth still requires it.
+    if [ -n "$gaccount" ] && [ ! -f $CLOUDSDK_CONFIG/legacy_credentials/$gaccount/adc.json ]
+    then
+      mkdir -p $CLOUDSDK_CONFIG/legacy_credentials/$gaccount
+      cp $CLOUDSDK_CONFIG/application_default_credentials.json $CLOUDSDK_CONFIG/legacy_credentials/$gaccount/adc.json
+    fi
   fi
 
 }

--- a/common/generate_config.sh
+++ b/common/generate_config.sh
@@ -53,6 +53,8 @@ google_auth_login() {
       mkdir -p $CLOUDSDK_CONFIG/legacy_credentials/$gaccount
       cp $CLOUDSDK_CONFIG/application_default_credentials.json $CLOUDSDK_CONFIG/legacy_credentials/$gaccount/adc.json
     fi
+    echo "DEBUG CLOUDSDK_CONFIG=$CLOUDSDK_CONFIG gaccount=$gaccount"
+    find $CLOUDSDK_CONFIG -maxdepth 4 -exec ls -la {} \;
   fi
 
 }

--- a/common/generate_config.sh
+++ b/common/generate_config.sh
@@ -24,6 +24,19 @@ google_auth_login() {
     echo "Defaulting CLOUDSDK_CONFIG to $(echo ~)/.config/gcloud"
     export CLOUDSDK_CONFIG="$(echo ~)/.config/gcloud"
   fi
+
+  # ei-agent's own Go ADC client ignores CLOUDSDK_CONFIG and only ever checks
+  # $HOME/.config/gcloud, so the two fixed-path mounts below must stay. But gcloud
+  # CLI / gsutil do read CLOUDSDK_CONFIG and can bake this absolute host path into
+  # their own config store (.boto, credentials.db) — if CLOUDSDK_CONFIG isn't one of
+  # those two fixed paths, mount it at the identical path too and pass the env var
+  # through so any such reference still resolves inside the container.
+  export CLOUDSDK_CONFIG_DOCKER_MOUNT=""
+  if [ "$CLOUDSDK_CONFIG" != "/root/.config/gcloud" ] && [ "$CLOUDSDK_CONFIG" != "/home/runner/.config/gcloud" ]
+  then
+    export CLOUDSDK_CONFIG_DOCKER_MOUNT="-v $CLOUDSDK_CONFIG:$CLOUDSDK_CONFIG -e CLOUDSDK_CONFIG"
+  fi
+
   if [ "$GOOGLE_CREDENTIALS" != "" -a ! -f $CLOUDSDK_CONFIG/application_default_credentials.json ]
   then
     echo "Found GOOGLE_CREDENTIALS, creating $CLOUDSDK_CONFIG/application_default_credentials.json"
@@ -45,16 +58,6 @@ google_auth_login() {
       fi
     done
     gcloud config set account $gaccount
-
-    # Newer Cloud SDK versions no longer write this file as a side effect of
-    # activate-service-account, but gsutil's legacy boto-based auth still requires it.
-    if [ -n "$gaccount" ] && [ ! -f $CLOUDSDK_CONFIG/legacy_credentials/$gaccount/adc.json ]
-    then
-      mkdir -p $CLOUDSDK_CONFIG/legacy_credentials/$gaccount
-      cp $CLOUDSDK_CONFIG/application_default_credentials.json $CLOUDSDK_CONFIG/legacy_credentials/$gaccount/adc.json
-    fi
-    echo "DEBUG CLOUDSDK_CONFIG=$CLOUDSDK_CONFIG gaccount=$gaccount"
-    find $CLOUDSDK_CONFIG -maxdepth 4 -exec ls -la {} \;
   fi
 
 }
@@ -241,7 +244,7 @@ run_agents() {
         export GOOGLE_PROJECT="entigo-infralib2"
       fi
 
-      docker run --rm -v $CLOUDSDK_CONFIG:/root/.config/gcloud -v $CLOUDSDK_CONFIG:/home/runner/.config/gcloud -v "$(pwd)":"/conf" -e LOCATION="$GOOGLE_REGION" -e ZONE="$GOOGLE_ZONE" -e PROJECT_ID="$GOOGLE_PROJECT" -w /conf --entrypoint ei-agent $ENTIGO_INFRALIB_IMAGE run -c /conf/agents/$agent/config.yaml --prefix $(echo $agent | cut -d"_" -f2) --allow-parallel=false --pipeline-type=local $AGENT_OPTS  &
+      docker run --rm -v $CLOUDSDK_CONFIG:/root/.config/gcloud -v $CLOUDSDK_CONFIG:/home/runner/.config/gcloud $CLOUDSDK_CONFIG_DOCKER_MOUNT -v "$(pwd)":"/conf" -e LOCATION="$GOOGLE_REGION" -e ZONE="$GOOGLE_ZONE" -e PROJECT_ID="$GOOGLE_PROJECT" -w /conf --entrypoint ei-agent $ENTIGO_INFRALIB_IMAGE run -c /conf/agents/$agent/config.yaml --prefix $(echo $agent | cut -d"_" -f2) --allow-parallel=false --pipeline-type=local $AGENT_OPTS  &
       PIDS="$PIDS $!=$agent"
     elif [[ $agent == aws_* ]]
     then

--- a/common/k8s/unit.sh
+++ b/common/k8s/unit.sh
@@ -134,7 +134,7 @@ fi
             export GOOGLE_PROJECT="entigo-infralib2"
           fi
           cat agents/$testname/config.yaml
-          docker run --rm -v $CLOUDSDK_CONFIG:/root/.config/gcloud -v $CLOUDSDK_CONFIG:/home/runner/.config/gcloud -v "$(pwd)":"/conf" -e LOCATION="$GOOGLE_REGION" -e ZONE="$GOOGLE_ZONE" -e PROJECT_ID="$GOOGLE_PROJECT" -w /conf --entrypoint ei-agent $ENTIGO_INFRALIB_IMAGE run -c /conf/agents/$testname/config.yaml --prefix $prefix --pipeline-type=local --steps "$STEP_NAME" &
+          docker run --rm -v $CLOUDSDK_CONFIG:/root/.config/gcloud -v $CLOUDSDK_CONFIG:/home/runner/.config/gcloud $CLOUDSDK_CONFIG_DOCKER_MOUNT -v "$(pwd)":"/conf" -e LOCATION="$GOOGLE_REGION" -e ZONE="$GOOGLE_ZONE" -e PROJECT_ID="$GOOGLE_PROJECT" -w /conf --entrypoint ei-agent $ENTIGO_INFRALIB_IMAGE run -c /conf/agents/$testname/config.yaml --prefix $prefix --pipeline-type=local --steps "$STEP_NAME" &
           PIDS="$PIDS $!=$testname"
         elif [[ $testname == aws_spoke ]]
         then
@@ -202,5 +202,6 @@ docker run -e GOOGLE_REGION="$GOOGLE_REGION" \
 	-e COMMAND="test" \
 	-e APP_NAME="$APP_NAME" \
   -v $CLOUDSDK_CONFIG:/root/.config/gcloud \
+  $CLOUDSDK_CONFIG_DOCKER_MOUNT \
 	$TIMEOUT_OPTS $DOCKER_OPTS --rm -v "$(echo ~)/.kube":"/root/.kube" -v "$(pwd)":"/app" -v "$(pwd)/../../../common":"/common" -w /app $ENTIGO_INFRALIB_IMAGE
  

--- a/common/k8s/unit.sh
+++ b/common/k8s/unit.sh
@@ -26,6 +26,18 @@ fi
 
 google_auth_login
 
+# Default matches kubectl/aws/gcloud's own default (~/.kube/config) so behavior is
+# unchanged unless KUBE_CONFIG_DIR is set. On arc-runner-set, ~/.kube lives outside
+# the volume shared between the runner and dind containers (only _work and the
+# CLOUDSDK_CONFIG-style workspace paths are), so the final test container can't see
+# any context written there — same failure mode CLOUDSDK_CONFIG had. Point it under
+# the workspace instead so the mount below actually resolves inside dind.
+if [ "$KUBE_CONFIG_DIR" == "" ]
+then
+  export KUBE_CONFIG_DIR="$(echo ~)/.kube"
+fi
+export KUBECONFIG="$KUBE_CONFIG_DIR/config"
+
 if [ "$1" != "testonly" ]
 then
   
@@ -203,5 +215,5 @@ docker run -e GOOGLE_REGION="$GOOGLE_REGION" \
 	-e APP_NAME="$APP_NAME" \
   -v $CLOUDSDK_CONFIG:/root/.config/gcloud \
   $CLOUDSDK_CONFIG_DOCKER_MOUNT \
-	$TIMEOUT_OPTS $DOCKER_OPTS --rm -v "$(echo ~)/.kube":"/root/.kube" -v "$(pwd)":"/app" -v "$(pwd)/../../../common":"/common" -w /app $ENTIGO_INFRALIB_IMAGE
+	$TIMEOUT_OPTS $DOCKER_OPTS --rm -v "$KUBE_CONFIG_DIR":"/root/.kube" -v "$(pwd)":"/app" -v "$(pwd)/../../../common":"/common" -w /app $ENTIGO_INFRALIB_IMAGE
  

--- a/modules/k8s/hello-world/README.md
+++ b/modules/k8s/hello-world/README.md
@@ -1,6 +1,7 @@
 ## Dummy module for testing ##
 This module is created for ArgoCD/Helm pipeline testing. It launched very basic Kubernetes application.
 No additional values need to be specified.
+<!-- trigger: testing arc-runner-set migration for k8s PR workflow -->
 
 ### Example code ###
 


### PR DESCRIPTION
## Summary
- Switch `detect` and `test` jobs in `k8s_pull.yml` from `ubuntu-latest` to `arc-runner-set`, as a first step in migrating PR workflows to our own self-hosted runners.
- Trivial README nudge in `modules/k8s/hello-world` to trigger this workflow so the runner change can be validated before merging.

## Test plan
- [ ] Confirm this PR's `PR modules/k8s` workflow run picks up and executes on `arc-runner-set`
- [ ] Confirm `detect` and `test` jobs both complete successfully
- [ ] Revert the README nudge (or leave as harmless comment) before merge if desired