### PR TITLE
Use internal gateway for kiali on AWS

### DIFF
--- a/modules/k8s/kiali/agent_input_aws.yaml
+++ b/modules/k8s/kiali/agent_input_aws.yaml
@@ -14,5 +14,5 @@ global:
   aws:
     createRoute: "{{ .tinput.aws-alb.global.createRoute }}"
     gateway:
-      name: "{{ .tinput.aws-alb.global.externalGateway }}"
+      name: "{{ .tinput.aws-alb.global.internalGateway }}"
       namespace: "{{ .tmodule.aws-alb }}"


### PR DESCRIPTION
## Summary

`modules/k8s/kiali/agent_input_aws.yaml` set `global.aws.gateway.name` from `aws-alb`'s `externalGateway`, but kiali's `web_fqdn` is built from `route53.int_domain` — so it was being attached to the external gateway while advertising an internal hostname.

Switched to `internalGateway`, which is what the other internal-facing modules use (`prometheus`, `grafana`, `loki`, `mimir`, `argocd`).

```diff
-      name: "{{ .tinput.aws-alb.global.externalGateway }}"
+      name: "{{ .tinput.aws-alb.global.internalGateway }}"
```

The Google agent input needed no change — it already resolves the hostname from `dns.int_domain` and does not reference an external gateway.

## Test plan

- [ ] Agent run renders kiali's HTTPRoute against the `internal` gateway in the `aws-alb` namespace
- [ ] Kiali is reachable on `<module>.<int_domain>` and no longer exposed via the external gateway

Note: the module's test suite was not run locally; this is a single template-reference change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)