### PR TITLE
Use internal gateway for kiali on AWS

### DIFF
--- a/modules/k8s/kiali/agent_input_aws.yaml
+++ b/modules/k8s/kiali/agent_input_aws.yaml
@@ -14,5 +14,5 @@ global:
   aws:
     createRoute: "{{ .tinput.aws-alb.global.createRoute }}"
     gateway:
-      name: "{{ .tinput.aws-alb.global.externalGateway }}"
+      name: "{{ .tinput.aws-alb.global.internalGateway }}"
       namespace: "{{ .tmodule.aws-alb }}"

--- a/modules/k8s/kiali/test/aws_biz.yaml
+++ b/modules/k8s/kiali/test/aws_biz.yaml
@@ -1,3 +1,7 @@
+global:
+  aws:
+    gateway:
+      name: external
 kiali-server:
   server:
     web_fqdn: "{{ .module.name }}.{{ .toutput.route53.pub_domain }}"
@@ -9,10 +13,3 @@ kiali-server:
       issuer_uri: "https://entigo-dev-if3upz.zitadel.cloud"
       scopes: ["openid", "profile", "email", "roles"]
       username_claim: "email"
-  deployment:
-    ingress:
-      override_yaml:
-        metadata:
-          annotations:
-            alb.ingress.kubernetes.io/group.name: external
-            alb.ingress.kubernetes.io/scheme: internet-facing

--- a/modules/k8s/kiali/test/aws_pri.yaml
+++ b/modules/k8s/kiali/test/aws_pri.yaml
@@ -1,3 +1,7 @@
+global:
+  aws:
+    gateway:
+      name: external
 kiali-server:
   auth:
     strategy: openid
@@ -7,10 +11,3 @@ kiali-server:
       issuer_uri: "https://entigo-dev-if3upz.zitadel.cloud"
       scopes: ["openid", "profile", "email", "roles"]
       username_claim: "email"
-  deployment:
-    ingress:
-      override_yaml:
-        metadata:
-          annotations:
-            alb.ingress.kubernetes.io/group.name: external
-            alb.ingress.kubernetes.io/scheme: internet-facing


### PR DESCRIPTION
Replaces #1669, which was closed when its branch was renamed to drop the `/`.

## Summary

`modules/k8s/kiali/agent_input_aws.yaml` set `global.aws.gateway.name` from `aws-alb`'s `externalGateway`, but kiali's `web_fqdn` is built from `route53.int_domain` — so it was being attached to the external gateway while advertising an internal hostname.

Switched to `internalGateway`, which is what the other internal-facing modules use (`prometheus`, `grafana`, `loki`, `mimir`, `argocd`).

```diff
-      name: "{{ .tinput.aws-alb.global.externalGateway }}"
+      name: "{{ .tinput.aws-alb.global.internalGateway }}"
```

The Google agent input needed no change — it already resolves the hostname from `dns.int_domain` and does not reference an external gateway.

## Test plan

- [ ] Agent run renders kiali's HTTPRoute against the `internal` gateway in the `aws-alb` namespace
- [ ] Kiali is reachable on `<module>.<int_domain>` and no longer exposed via the external gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)