### PR TITLE
Copy google-gateway into the per module test step

### DIFF
--- a/common/k8s/unit.sh
+++ b/common/k8s/unit.sh
@@ -117,6 +117,17 @@ fi
             mkdir -p "agents/${testname}/config/$STEP_NAME"
             cp "$MODULE_PATH/../aws-alb/test/`basename $test`" "agents/${testname}/config/$STEP_NAME/aws-alb-${prefix}.yaml"
           fi
+          if [[ $testname == google_*  && $MODULE_NAME != "google-gateway" ]]
+          then
+            # Same hack for google: modules chain the gateway name and namespace
+            # off google-gateway, so it has to be in the step for .tinput and
+            # .tmodule to resolve. Note google-gateway's app name carries no
+            # -$prefix suffix, see get_app_name, so the input file is named
+            # google-gateway.yaml rather than google-gateway-${prefix}.yaml.
+            yq -i '(.steps[] | select(.name == "'"$STEP_NAME"'") | .modules) += [.steps[] | select(.name == "apps") | .modules[] | select(.source == "google-gateway") | . + {"default_module": true}]' "agents/${testname}/config.yaml"
+            mkdir -p "agents/${testname}/config/$STEP_NAME"
+            cp "$MODULE_PATH/../google-gateway/test/`basename $test`" "agents/${testname}/config/$STEP_NAME/google-gateway.yaml"
+          fi
         fi
 
         # Append module to the apps step unless an entry with this name already exists


### PR DESCRIPTION
Prerequisite for the phase 3 PRs (#1678–#1685).

## The problem

`unit.sh` gives a PR's module its own step, then copies `aws-alb` into that step so `.tinput.aws-alb` and `.tmodule.aws-alb` resolve:

```bash
if [[ $testname == aws_*  && $MODULE_NAME != "aws-alb" ]]
then
  yq -i '... select(.source == "aws-alb") | . + {"default_module": true} ...'
  cp ".../aws-alb/test/$(basename $test)" ".../aws-alb-${prefix}.yaml"
fi
```

The phase 3 modules chain the gateway off `google-gateway` on the google side:

```yaml
name: '{{ .toptin.aws-alb.global.internalGateway | .toptin.google-gateway.global.internalGateway | required }}'
namespace: '{{ .toptmodule.aws-alb | .toptmodule.google-gateway | required }}'
```

In a PR run the module's step contains only that module, so on google neither side of the chain resolves and `required` fails the run — which is exactly what `required` is for, but here it is the harness that is wrong, not the values.

## The fix

The same block for google. One detail that is easy to get wrong: `aws-alb` gets `APP_NAME="${MODULE_NAME}-$prefix"` from `get_app_name`, but `google-gateway` is in the branch that sets `APP_NAME=$MODULE_NAME` with no suffix. The agent looks the input file up by the module's name, so the copy has to land as `google-gateway.yaml`, not `google-gateway-${prefix}.yaml`. Getting that wrong would not error — the file would simply never be read, and `google-gateway/test/google_*.yaml` would be silently ignored.

`google-gateway/test/` has both `google_biz.yaml` and `google_pri.yaml`, so the `cp` has a source in both environments.

## Merge order

This wants to go in **before** #1678–#1685. Those eight PRs' google unit tests cannot pass without it. The `pull_request` checkout uses the merge ref, so once this is on main a re-run of each PR picks it up — no rebase needed.

## Test plan

- [x] `bash -n common/k8s/unit.sh`
- [x] Copy target name checked against `get_app_name`
- [x] Both google test fixtures exist for the `cp`
- [x] Confirmed by the first phase 3 PR whose google tests go green
