### PR TITLE
google-gateway: point the test environments at the external gateway

### DIFF
--- a/modules/k8s/google-gateway/test/google_biz.yaml
+++ b/modules/k8s/google-gateway/test/google_biz.yaml
@@ -1,3 +1,11 @@
+# Point the modules that ask for the internal gateway at the external one, the
+# same thing aws-alb/test/aws_*.yaml does with internalGateway: external. Test
+# environments are short lived and have to be reachable without a VPN, and the
+# unit tests ask for the external gateway. Google names its gateways
+# <release name>-<key>, so this resolves to google-gateway-external.
+global:
+  internalGateway: "{{ .module.name }}-external"
+
 gateways:
   external:
     sslPolicy: "{{ .toptout.dns.ssl_policy_restricted }}"

--- a/modules/k8s/google-gateway/test/google_pri.yaml
+++ b/modules/k8s/google-gateway/test/google_pri.yaml
@@ -1,3 +1,11 @@
+# Point the modules that ask for the internal gateway at the external one, the
+# same thing aws-alb/test/aws_*.yaml does with internalGateway: external. Test
+# environments are short lived and have to be reachable without a VPN, and the
+# unit tests ask for the external gateway. Google names its gateways
+# <release name>-<key>, so this resolves to google-gateway-external.
+global:
+  internalGateway: "{{ .module.name }}-external"
+
 gateways:
   internal:
     enabled: false


### PR DESCRIPTION
Second prerequisite for the phase 3 PRs, after #1686.

## What it does

`google-gateway/test/google_biz.yaml` and `google_pri.yaml` now set

```yaml
global:
  internalGateway: "{{ .module.name }}-external"
```

which is the direct counterpart of `internalGateway: external` in `aws-alb/test/aws_*.yaml`. Google names its gateways `<release name>-<key>`, so this resolves to `google-gateway-external` — the full object name, not a bare key like on AWS. Writing it as `{{ .module.name }}-external` rather than the literal keeps it correct if the module is ever deployed under a different name, which is exactly how `agent_input_google.yaml` already sets `internalGateway` and `externalGateway`.

## Why

Every phase 3 module chains its gateway off `internalGateway`, so pinning it once here replaces six per-module pins in the test values. I have already dropped those from the phase 3 branches:

| PR | dropped from |
|---|---|
| #1678 grafana | `google_biz`, `google_pri` |
| #1679 prometheus | `google_pri` |
| #1680 loki | `google_pri` |
| #1681 argocd | `google_biz`, `google_pri` |
| #1683 kiali | `google_biz`, `google_pri` |
| #1684 mimir | `google_pri` |

`harbor` (#1682) and `istio-gateway` (#1685) never needed one — they chain off `externalGateway`.

Hostname overrides stay where they were: argocd, grafana and kiali still point `google_biz` at `pub_domain`. Only the gateway pin goes.

## Verified

Rendered each of the six on google for both environments with this fixture applied the way `unit.sh` applies it, and with the module's own pin removed. All twelve land on `google-gateway-external` in namespace `google-gateway`, with the hostnames unchanged:

```
grafana/google_pri     -> google-gateway-external  [grafana.<int_domain>]
grafana/google_biz     -> google-gateway-external  [grafana.<pub_domain>]
prometheus/google_pri  -> google-gateway-external  [prometheus.<int_domain>]
prometheus/google_biz  -> google-gateway-external  [prometheus.<int_domain>]
loki/google_pri        -> google-gateway-external  [loki.<int_domain>]
loki/google_biz        -> google-gateway-external  [loki.<int_domain>]
argocd/google_pri      -> google-gateway-external  [argocd.<pub_domain>]
argocd/google_biz      -> google-gateway-external  [argocd.<pub_domain>]
kiali/google_pri       -> google-gateway-external  [kiali.<int_domain>]
kiali/google_biz       -> google-gateway-external  [kiali.<pub_domain>]
mimir/google_pri       -> google-gateway-external  [mimir.<int_domain>]
mimir/google_biz       -> google-gateway-external  [mimir.<int_domain>]
```

## One thing I could not check

`loki`, `prometheus` and `mimir` call `k8s.GetGatewayConfig(t, cloudName, envName, "default")` rather than `"external"`, and today those three sit on the **internal** gateway in `google_biz`. This change moves them to external there. I cannot read `GetGatewayConfig` — `entigo-infralib-common` is not reachable from my environment — so I cannot confirm what `"default"` resolves to on google biz.

The reason I think it is fine: on AWS, `aws-alb/test/aws_biz.yaml` sets both `internalGateway: external` **and** `gateways.internal.enabled: false`, so those same three modules and those same `"default"` assertions already run against an external-only environment and pass. If `"default"` meant "the internal gateway", AWS biz would already be failing.

Worth a glance from someone who can read that function before merging, since it is the one claim here I have not verified myself.

## Merge order

After #1686, before #1678–#1685. Inert on its own: nothing on `main` reads `google-gateway`'s `internalGateway` yet.

## Test plan

- [x] Twelve renders verified as above
- [x] `harbor` and `istio-gateway` unaffected, they chain off `externalGateway`
- [ ] `GetGatewayConfig(..., "default")` behaviour on google biz — see above
- [ ] CI
