### PR TITLE
mimir: stop gating the TargetGroupConfiguration on the removed aws.createRoute

### DIFF
--- a/modules/k8s/mimir/templates/aws/targetGroupConfiguration.yaml
+++ b/modules/k8s/mimir/templates/aws/targetGroupConfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.global.cloudProvider "aws") .Values.global.aws.createRoute }}
+{{- if eq .Values.global.cloudProvider "aws" }}
 apiVersion: gateway.k8s.aws/v1beta1
 kind: TargetGroupConfiguration
 metadata:


### PR DESCRIPTION
Follow-up fix to #1684.

## Problem

#1684 moved mimir's route flag from `global.aws.createRoute` to `global.createRoute` and dropped the `createRoute` line from `agent_input_aws.yaml`. `templates/httpRoute.yaml` was updated to the new value; `templates/aws/targetGroupConfiguration.yaml` was not.

`.Values.global.aws.createRoute` is now unset everywhere in the chart — `values.yaml`, `values-aws.yaml` and `agent_input_aws.yaml` — so the gate always evaluates nil, the resource stops rendering, and Argo wants to delete the `TargetGroupConfiguration` on AWS.

## Fix

Render it whenever the cloud provider is AWS, dropping the route gate entirely:

```diff
-{{- if and (eq .Values.global.cloudProvider "aws") .Values.global.aws.createRoute }}
+{{- if eq .Values.global.cloudProvider "aws" }}
```

This matches grafana, harbor, kiali and prometheus. The target group configuration should exist before the route is switched on, and should not be deleted and recreated as environments move through the Ingress-to-Gateway migration phases.

## Verification

`helm template` against `values-aws.yaml` with `createRoute` at its default `false` now renders the resource, and the full chart templates cleanly for both clouds (google emits no `TargetGroupConfiguration`).

## Not in this PR

- `modules/k8s/saml-proxy/templates/targetGroupConfiguration.yaml` also gates on `global.aws.createRoute`, but saml-proxy has not been converted to the cloud-neutral httpRoute yet and still sets that value in its own `agent_input_aws.yaml`, so it works today. It needs the same change when saml-proxy is converted.
- loki and argocd gate their `TargetGroupConfiguration` on their own route-enabled flags (`loki.gateway.route.main.enabled`, `argocd.server.grpcroute.enabled`) — same delete-on-flip pattern, left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)