### PR TITLE
karpenter: read the nodepool flag from global.createNodepool

### DIFF
--- a/modules/k8s/karpenter/templates/nodePool.yaml
+++ b/modules/k8s/karpenter/templates/nodePool.yaml
@@ -1,6 +1,6 @@
 {{- if eq .Values.global.cloudProvider "aws" }}
 
-{{- if .Values.createNodepool }}
+{{- if .Values.global.createNodepool }}
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:


### PR DESCRIPTION
## Problem

`karpenter/values.yaml:10` declares the flag under `global:`:

```yaml
global:
  createNodepool: false
```

but `templates/nodePool.yaml:3` gated on the top level value:

```
{{- if .Values.createNodepool }}
```

Nothing in the repository sets a top level `createNodepool`, so the gate was always nil and the `NodePool` was never rendered, no matter what `global.createNodepool` was set to.

## Fix

Read the flag from where it is declared:

```diff
-{{- if .Values.createNodepool }}
+{{- if .Values.global.createNodepool }}
```

`global.createNodepool` is the correct home for it — it sits with `global.nodeRoleName` and `global.nodeRoleARN`, which the same template already reads from `global`.

## Verification

`helm template` with `values.yaml -f values-aws.yaml -f test/static_values.yaml`:

- `--set global.createNodepool=true` now renders one `kind: NodePool` (previously zero)
- default (`false`) renders none, unchanged
- the static render (`values.yaml` + `static_values.yaml`) and `helm lint --strict` both pass

## Note

No environment currently sets `createNodepool`, so nothing in the test platforms or in gitops starts creating a NodePool because of this change. Any platform that had set `global.createNodepool: true` expecting it to work will start getting the NodePool it asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)