### PR TITLE
crossplane-aws: fix typos in the activation policy comment

### DIFF
--- a/modules/k8s/crossplane-aws/templates/mrap.yaml
+++ b/modules/k8s/crossplane-aws/templates/mrap.yaml
@@ -1,4 +1,4 @@
-#Due to a bug we must activate the namesapced and non namespaced observers at differnet time.
+#Due to a bug we must activate the namespaced and non namespaced observers at different time.
 {{- if .Values.global.createNamespacedObservers }}
 apiVersion: apiextensions.crossplane.io/v1alpha1
 kind: ManagedResourceActivationPolicy


### PR DESCRIPTION
Comment-only typo fix in `modules/k8s/crossplane-aws/templates/mrap.yaml:1`.

```diff
-#Due to a bug we must activate the namesapced and non namespaced observers at differnet time.
+#Due to a bug we must activate the namespaced and non namespaced observers at different time.
```

`namesapced` -> `namespaced`, `differnet` -> `different`. No rendered output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)