### PR TITLE
mimir: fix "tenent" typo in the series limit comment

### DIFF
--- a/modules/k8s/mimir/values-aws.yaml
+++ b/modules/k8s/mimir/values-aws.yaml
@@ -142,7 +142,7 @@ mimir-distributed:
         # Avoid caching results newer than 10m because some samples can be delayed
         # This presents caching incomplete results
         max_cache_freshness: 10m
-        #Per tenent series limit
+        #Per tenant series limit
         max_global_series_per_user: 1500000
         max_global_series_per_metric: 0
         max_label_names_per_series: 60

--- a/modules/k8s/mimir/values-google.yaml
+++ b/modules/k8s/mimir/values-google.yaml
@@ -127,7 +127,7 @@ mimir-distributed:
         # Avoid caching results newer than 10m because some samples can be delayed
         # This presents caching incomplete results
         max_cache_freshness: 10m
-        #Per tenent series limit
+        #Per tenant series limit
         max_global_series_per_user: 1500000
         max_global_series_per_metric: 0
         max_label_names_per_series: 60


### PR DESCRIPTION
Comment-only typo fix.

```diff
-        #Per tenent series limit
+        #Per tenant series limit
```

`modules/k8s/mimir/values-aws.yaml:145` and `modules/k8s/mimir/values-google.yaml:130`. No rendered output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)