### PR TITLE
mimir: fix "evaulated" typo in the mimir.config comment

### DIFF
--- a/modules/k8s/mimir/values-aws.yaml
+++ b/modules/k8s/mimir/values-aws.yaml
@@ -26,7 +26,7 @@ mimir-distributed:
           paths:
             - path: /
   mimir:
-    # -- Base config file for Grafana Mimir and Grafana Enterprise Metrics. Contains Helm templates that are evaulated at install/upgrade.
+    # -- Base config file for Grafana Mimir and Grafana Enterprise Metrics. Contains Helm templates that are evaluated at install/upgrade.
     # To modify the resulting configuration, either copy and alter 'mimir.config' as a whole or use the 'mimir.structuredConfig' to add and modify certain YAML elements.
     config: |
       usage_stats:

--- a/modules/k8s/mimir/values-google.yaml
+++ b/modules/k8s/mimir/values-google.yaml
@@ -16,7 +16,7 @@ mimir-distributed:
       enabled: false
 
   mimir:
-    # -- Base config file for Grafana Mimir and Grafana Enterprise Metrics. Contains Helm templates that are evaulated at install/upgrade.
+    # -- Base config file for Grafana Mimir and Grafana Enterprise Metrics. Contains Helm templates that are evaluated at install/upgrade.
     # To modify the resulting configuration, either copy and alter 'mimir.config' as a whole or use the 'mimir.structuredConfig' to add and modify certain YAML elements.
     config: |
       usage_stats:


### PR DESCRIPTION
Comment-only typo fix.

```diff
-    # -- Base config file for Grafana Mimir and Grafana Enterprise Metrics. Contains Helm templates that are evaulated at install/upgrade.
+    # -- Base config file for Grafana Mimir and Grafana Enterprise Metrics. Contains Helm templates that are evaluated at install/upgrade.
```

`modules/k8s/mimir/values-aws.yaml:29` and `modules/k8s/mimir/values-google.yaml:19`. No rendered output changes.

**Note:** this line is copied verbatim from the upstream `mimir-distributed` values, where the typo also exists. Fixing it here means step 4 of the dependency-update procedure ("diff the upstream values against ours") will show this line as a local deviation. Close this one if you would rather keep our copies byte-identical to upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)