### PR TITLE
crossplane-core: fix two typos in the values comments

### DIFF
--- a/modules/k8s/crossplane-core/values.yaml
+++ b/modules/k8s/crossplane-core/values.yaml
@@ -76,7 +76,7 @@ crossplane:
     managementPolicy: All
     # -- Enable leader election for RBAC Managers pod.
     leaderElection: true
-    # -- A list of additional args to be pased to the RBAC manager's container.
+    # -- A list of additional args to be passed to the RBAC manager's container.
     args: []
     # -- Enable nodeSelector for RBAC Managers pod.
     affinity:
@@ -172,7 +172,7 @@ crossplane:
   # -- List of extra Volumes to add to Crossplane.
   extraVolumesCrossplane: {}
 
-  # -- List of extra volumesMounts to add to Crossplane.
+  # -- List of extra volumeMounts to add to Crossplane.
   extraVolumeMountsCrossplane: {}
 
   xfn:


### PR DESCRIPTION
Comment-only typo fixes in `modules/k8s/crossplane-core/values.yaml`.

Line 79:
```diff
-    # -- A list of additional args to be pased to the RBAC manager's container.
+    # -- A list of additional args to be passed to the RBAC manager's container.
```

Line 175 — the comment documents `extraVolumeMountsCrossplane`, so the field name in it should read `volumeMounts`:
```diff
-  # -- List of extra volumesMounts to add to Crossplane.
+  # -- List of extra volumeMounts to add to Crossplane.
```

No rendered output changes.

**Note:** both lines are copied verbatim from the upstream crossplane values, where the typos also exist. Fixing them here means step 4 of the dependency-update procedure ("diff the upstream values against ours") will show these lines as local deviations. Close this one if you would rather keep our copies byte-identical to upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)