### PR TITLE
trivy: add the missing space in the .config.prefix tag

### DIFF
--- a/modules/k8s/trivy/agent_input_aws.yaml
+++ b/modules/k8s/trivy/agent_input_aws.yaml
@@ -1,5 +1,5 @@
 global:
-  prefix: "{{ .config.prefix}}"
+  prefix: "{{ .config.prefix }}"
   aws:
     account: "{{ .toutput.eks.account }}"
     clusterOIDC: "{{ .toutput.eks.oidc_provider }}"


### PR DESCRIPTION
`modules/k8s/trivy/agent_input_aws.yaml:2` was the only replacement tag in `modules/k8s` written without the closing space:

```diff
-  prefix: "{{ .config.prefix}}"
+  prefix: "{{ .config.prefix }}"
```

The agent resolves both spellings identically, so the rendered value does not change — this is purely to match the convention used everywhere else.

**Note:** `global.prefix` on trivy is dead (nothing in the chart or its subchart reads it), so this tag is resolved for nothing. Removing it is a separate question and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)