### PR TITLE
report: skip deprecated modules

### DIFF
--- a/common/k8s/report.sh
+++ b/common/k8s/report.sh
@@ -3,8 +3,20 @@ SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 cd $SCRIPTPATH/../..
 
 
+# A deprecated module keeps shipping so platforms can finish migrating off it,
+# but its upstream chart and providers are no longer followed. Skipping them
+# keeps the report, and the update pull requests generated from it, clean.
+deprecated_module() {
+  local chart="$1/Chart.yaml"
+  [ -f "$chart" ] && [ "$(yq -r '.deprecated // false' "$chart")" == "true" ]
+}
+
 for chart in $(find modules/k8s/ -name Chart.yaml | sort)
 do
+  if deprecated_module "$(dirname $chart)"
+  then
+    continue
+  fi
   yq -r '.dependencies[] | "\(.name) \(.version) \(.repository)"' $chart | while read dep
   do
     if [ "$dep" != "" ]
@@ -63,6 +75,12 @@ done
 
 for providerfile in $(find modules/k8s/ -name provider.yaml | sort)
 do
+  # provider.yaml sits at varying depths under templates/, so take the module
+  # root, modules/k8s/<module>, rather than the file's own directory
+  if deprecated_module "$(echo $providerfile | cut -d/ -f1-3)"
+  then
+    continue
+  fi
   cat $providerfile | grep xpkg.upbound.io | grep -ve"\$provider" | cut -d"/" -f2- | while read provider
   do
     old_version=$(echo $provider | cut -d":" -f2)

--- a/modules/k8s/README.md
+++ b/modules/k8s/README.md
@@ -462,3 +462,32 @@ environment. This is where cloud specific templates actually get verified.
 8. `test/static_values.yaml` only if the chart cannot render without it.
 9. Add the module to `test_k8s()` in `common/generate_config.sh`.
 10. Run `./test.sh` before opening the pull request.
+
+## Deprecating a module
+
+A module is never simply deleted. Platforms that have not run the migration yet
+would break on the next agent run, so a replaced module keeps shipping,
+unchanged, until everyone has moved off it.
+
+1. Set `deprecated: true` in the module's `Chart.yaml`. This is Helm's own
+   field, so `helm template` prints `this chart is deprecated` on stderr and
+   `helm show chart` reports it, and it is what the tooling keys off — the
+   reports in `common/*/report.sh` skip deprecated modules so an upstream
+   release does not turn into an update pull request for a module nobody is
+   supposed to adopt.
+2. Write the module's `README.md`, starting with a `## Deprecated` section that
+   names the replacement, followed by numbered migration steps: the agent
+   configuration before and after, how to verify the replacement is working,
+   and how to remove the old app and namespace. `promtail` and
+   `argocd-ecr-updater` are the examples to copy.
+3. Delete `test/<cloud>_<env>.yaml` and `test/*_test.go` together. The
+   environment inputs are what put the module into the test platforms, via
+   `full_k8s_conf`, and `common/k8s/unit.sh` derives the environments to deploy
+   into from those same files — so a unit test left behind would wait for a
+   deployment that no longer happens. Remove the module from `test_k8s()` in
+   `common/generate_config.sh` if it is listed there.
+4. Leave `Chart.yaml`'s dependency, `values*.yaml`, the agent inputs and
+   `templates/` exactly as they are. Existing installations keep rendering the
+   same manifests.
+
+The module can be deleted once no platform references it any more.

--- a/modules/k8s/README.md
+++ b/modules/k8s/README.md
@@ -480,13 +480,24 @@ unchanged, until everyone has moved off it.
    configuration before and after, how to verify the replacement is working,
    and how to remove the old app and namespace. `promtail` and
    `argocd-ecr-updater` are the examples to copy.
-3. Delete `test/<cloud>_<env>.yaml` and `test/*_test.go` together. The
-   environment inputs are what put the module into the test platforms, via
-   `full_k8s_conf`, and `common/k8s/unit.sh` derives the environments to deploy
-   into from those same files — so a unit test left behind would wait for a
-   deployment that no longer happens. Remove the module from `test_k8s()` in
+3. Delete `test/<cloud>_<env>.yaml`. Those files are what put the module into
+   the test platforms, through `full_k8s_conf`, so removing them takes it out
+   of the test clusters. Remove the module from `test_k8s()` in
    `common/generate_config.sh` if it is listed there.
-4. Leave `Chart.yaml`'s dependency, `values*.yaml`, the agent inputs and
+4. Short circuit `test.sh` so nothing tries to test a module that is no longer
+   deployed anywhere:
+
+   ```bash
+   #!/bin/bash
+   exit 0 # Disable k8s/<module> tests, deprecated in favour of k8s/<replacement>
+   #SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+   #cd $SCRIPTPATH
+   #exec $SCRIPTPATH/../../../common/test.sh "$@"
+   ```
+
+   Keep `test/k8s_unit_basic_test.go` in case the module is ever picked back
+   up. With `test.sh` returning 0 the file costs nothing.
+5. Leave `Chart.yaml`'s dependency, `values*.yaml`, the agent inputs and
    `templates/` exactly as they are. Existing installations keep rendering the
    same manifests.
 

--- a/modules/k8s/argocd-ecr-updater/Chart.yaml
+++ b/modules/k8s/argocd-ecr-updater/Chart.yaml
@@ -3,6 +3,7 @@ name: argocd-ecr-updater
 description: argocd-ecr-updater
 version: 0.1.0
 appVersion: "0.1.0"
+deprecated: true
 
 dependencies:
 - name: argocd-ecr-updater

--- a/modules/k8s/promtail/Chart.yaml
+++ b/modules/k8s/promtail/Chart.yaml
@@ -4,6 +4,7 @@ description: A Promtail chart for Kubernetes
 type: application
 version: 0.1.0
 appVersion: "1.0"
+deprecated: true
 
 dependencies:
 - name: promtail


### PR DESCRIPTION
## Why

`common/k8s/report.sh` runs every Monday from `.github/workflows/report.yaml` and again from `prompts.sh update`, which feeds the report to Claude Code to open the `chore(deps): update ...` pull requests. A deprecated module still has an upstream chart pinned in its `Chart.yaml`, so the next time that chart releases the report shows an update and the automation turns it into a pull request for a module nobody is supposed to adopt.

Both deprecated modules happen to be at the latest upstream version right now (promtail `6.17.1`, argocd-ecr-updater `0.3.39`), so this is preventative rather than fixing a report that is noisy today.

## How deprecation is marked

`deprecated: true` in the module's `Chart.yaml` — Helm's own field, not a convention of ours:

```diff
 apiVersion: v2
 name: promtail
 version: 0.1.0
 appVersion: "1.0"
+deprecated: true
 dependencies:
 - name: promtail
   version: 6.17.1
```

Why this rather than parsing the README or keeping a list in `common/`:

- `report.sh` already parses every `Chart.yaml` with `yq`, so the check is a one-line helper instead of new plumbing.
- The flag lives next to the module, so it cannot drift the way a central list would.
- `helm template` prints `level=WARN msg="this chart is deprecated"` on **stderr** and `helm show chart` reports it, so the marker is visible to anyone rendering the chart.
- A README `## Deprecated` heading is prose. A grep for it breaks the moment someone writes `## Deprecated - use alloy`, and a loose `grep -i deprecat` would match any README that merely mentions a deprecated upstream flag.

The README stays as the human-facing migration guide; the Chart.yaml flag is what tooling reads.

## Changes

- `deprecated: true` on `modules/k8s/promtail/Chart.yaml` and `modules/k8s/argocd-ecr-updater/Chart.yaml`
- A `deprecated_module` helper in `common/k8s/report.sh`, applied to **both** loops. The crossplane provider loop takes the module root (`modules/k8s/<module>`, via `cut -d/ -f1-3`) rather than the file's own directory, because `provider.yaml` sits at varying depths under `templates/` — `crossplane-aws/templates/provider.yaml` but `crossplane-kafka/templates/aws/provider.yaml`.
- A `## Deprecating a module` section in `modules/k8s/README.md`, next to `## Adding a new module`, recording the five steps and why the module is not just deleted: the `Chart.yaml` flag, the migration README, deleting `test/<cloud>_<env>.yaml`, short circuiting `test.sh` with `exit 0` the way `promtail/test.sh` already does, and keeping everything else — including `test/k8s_unit_basic_test.go` — untouched.

## Verification

- `bash -n common/k8s/report.sh` passes.
- Dry run of both loops over the real tree: the chart loop skips exactly `modules/k8s/argocd-ecr-updater` and `modules/k8s/promtail`; the provider loop still processes all four crossplane modules, with the module root resolved correctly for the nested `crossplane-kafka` path.
- `yq -r '.deprecated // false'` returns `true` with the field, `false` when the field is absent and `false` when it is explicitly false, so nothing else is affected.
- Both deprecated modules still pass `helm lint --strict` (rc=0, no new warning) and still render — `helm template` emits the deprecation warning on stderr only, so it does not enter the manifest stream that `common/k8s/static.sh` pipes into kube-score, and ArgoCD's repo-server render is unaffected. The rendered manifests do not change.

## Related

- #1697 adds the migration guide README for `argocd-ecr-updater`, removes its test environment inputs and short circuits its `test.sh`. That PR and this one touch different files and merge independently, but if #1697 is not taken then `argocd-ecr-updater` ends up flagged deprecated here without its migration guide.
- `common/aws/report.sh` and `common/google/report.sh` need no deprecation filter — the Terraform modules have no `Chart.yaml` and none are deprecated. Their move from the Terraform registry to the OpenTofu registry is a separate pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
