### PR TITLE
report: look versions up in the OpenTofu registry

### DIFF
--- a/common/aws/report.sh
+++ b/common/aws/report.sh
@@ -17,10 +17,14 @@ do
   namespace=$(echo $line | cut -d"/" -f1)
   name=$(echo $line | cut -d"/" -f2 | cut -d"=" -f1)
   currentversion=$(echo $line | cut -d"=" -f2-)
-  registry=`curl -s "https://registry.terraform.io/v2/providers/$namespace/$name?include=latest-version&name=$name&namespace=$namespace"`
-  versionid=`echo $registry | jq -r '.data.relationships["latest-version"].data.id'`
-  latestversion=`echo $registry | jq -r --arg id "$versionid" '.included[] | select(.id == $id) | .attributes.version'`
-  if [[ "$currentversion" != "$latestversion" && "$currentversion" != ">="* ]]
+  # OpenTofu registry, standard registry protocol. Unlike the Terraform
+  # registry's v2 API it returns every version rather than a latest pointer, so
+  # drop prereleases and take the highest.
+  latestversion=`curl -s "https://registry.opentofu.org/v1/providers/$namespace/$name/versions" | jq -r '.versions[]?.version' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1`
+  if [ "$latestversion" == "" ]
+  then
+     echo "$namespace/$name provider not found in https://registry.opentofu.org/v1/providers/$namespace/$name/versions"
+  elif [[ "$currentversion" != "$latestversion" && "$currentversion" != ">="* ]]
   then
      echo "$namespace/$name newer version $latestversion, current $currentversion"
   fi
@@ -40,11 +44,12 @@ do
   name=$(echo $line | cut -d"=" -f1)
   name=${name%%//*}
   currentversion=$(echo $line | cut -d"=" -f2)
-  registry=`curl -s "https://registry.terraform.io/v2/modules/$name?include=latest-version"`
-  
-  versionid=`echo $registry | jq -r '.data.relationships["latest-version"].data.id'`
-  latestversion=`echo $registry | jq -r --arg id "$versionid" '.included[] | select(.id == $id) | .attributes.version'`
-  if [ "$currentversion" != "$latestversion" ]
+  # $name is already namespace/name/system, which is what the module endpoint takes
+  latestversion=`curl -s "https://registry.opentofu.org/v1/modules/$name/versions" | jq -r '.modules[0].versions[]?.version' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1`
+  if [ "$latestversion" == "" ]
+  then
+     echo "$name module not found in https://registry.opentofu.org/v1/modules/$name/versions"
+  elif [ "$currentversion" != "$latestversion" ]
   then
      echo "$name newer version $latestversion, current $currentversion"
   fi

--- a/common/google/report.sh
+++ b/common/google/report.sh
@@ -17,10 +17,14 @@ do
   namespace=$(echo $line | cut -d"/" -f1)
   name=$(echo $line | cut -d"/" -f2 | cut -d"=" -f1)
   currentversion=$(echo $line | cut -d"=" -f2)
-  registry=`curl -s "https://registry.terraform.io/v2/providers/$namespace/$name?include=latest-version&name=$name&namespace=$namespace"`
-  versionid=`echo $registry | jq -r '.data.relationships["latest-version"].data.id'`
-  latestversion=`echo $registry | jq -r --arg id "$versionid" '.included[] | select(.id == $id) | .attributes.version'`
-  if [ "$currentversion" != "$latestversion" ]
+  # OpenTofu registry, standard registry protocol. Unlike the Terraform
+  # registry's v2 API it returns every version rather than a latest pointer, so
+  # drop prereleases and take the highest.
+  latestversion=`curl -s "https://registry.opentofu.org/v1/providers/$namespace/$name/versions" | jq -r '.versions[]?.version' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1`
+  if [ "$latestversion" == "" ]
+  then
+     echo "$namespace/$name provider not found in https://registry.opentofu.org/v1/providers/$namespace/$name/versions"
+  elif [ "$currentversion" != "$latestversion" ]
   then
      echo "$namespace/$name newer version $latestversion, current $currentversion"
   fi
@@ -40,11 +44,12 @@ do
   name=$(echo $line | cut -d"=" -f1)
   name=${name%%//*}
   currentversion=$(echo $line | cut -d"=" -f2)
-  registry=`curl -s "https://registry.terraform.io/v2/modules/$name?include=latest-version"`
-  
-  versionid=`echo $registry | jq -r '.data.relationships["latest-version"].data.id'`
-  latestversion=`echo $registry | jq -r --arg id "$versionid" '.included[] | select(.id == $id) | .attributes.version'`
-  if [ "$currentversion" != "$latestversion" ]
+  # $name is already namespace/name/system, which is what the module endpoint takes
+  latestversion=`curl -s "https://registry.opentofu.org/v1/modules/$name/versions" | jq -r '.modules[0].versions[]?.version' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1`
+  if [ "$latestversion" == "" ]
+  then
+     echo "$name module not found in https://registry.opentofu.org/v1/modules/$name/versions"
+  elif [ "$currentversion" != "$latestversion" ]
   then
      echo "$name newer version $latestversion, current $currentversion"
   fi


### PR DESCRIPTION
## Why

`common/aws/report.sh` and `common/google/report.sh` both looked versions up at `registry.terraform.io/v2/...`. That is the Terraform registry website's JSON:API and has no OpenTofu equivalent, so with the move to OpenTofu the reports were checking a registry we no longer resolve modules from.

## Change

Move both scripts to the standard registry protocol v1 endpoints on `registry.opentofu.org`, which OpenTofu implements:

```diff
-  registry=`curl -s "https://registry.terraform.io/v2/providers/$namespace/$name?include=latest-version&name=$name&namespace=$namespace"`
-  versionid=`echo $registry | jq -r '.data.relationships["latest-version"].data.id'`
-  latestversion=`echo $registry | jq -r --arg id "$versionid" '.included[] | select(.id == $id) | .attributes.version'`
+  latestversion=`curl -s "https://registry.opentofu.org/v1/providers/$namespace/$name/versions" | jq -r '.versions[]?.version' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1`
```

```diff
-  registry=`curl -s "https://registry.terraform.io/v2/modules/$name?include=latest-version"`
-  versionid=`echo $registry | jq -r '.data.relationships["latest-version"].data.id'`
-  latestversion=`echo $registry | jq -r --arg id "$versionid" '.included[] | select(.id == $id) | .attributes.version'`
+  latestversion=`curl -s "https://registry.opentofu.org/v1/modules/$name/versions" | jq -r '.modules[0].versions[]?.version' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1`
```

Two notes on the shape of the new API:

- v1 returns the **full version list** rather than a latest pointer, so prereleases are dropped and the highest is taken with `sort -V` — the same approach `common/k8s/report.sh` already uses to pick the newest OCI tag.
- Module paths are already `namespace/name/system` after the existing `awk` extraction, which is exactly what the v1 module endpoint takes, so nothing about the parsing changes.

Also **report an empty lookup as not found** rather than printing `newer version ` with a blank version, matching how `common/k8s/report.sh` already reports a chart it cannot find. Previously a failed lookup produced a line claiming an update to `null`.

## Verification

Both scripts run clean against the live registry, and every provider and module in both trees resolves — no "not found" lines.

`common/google/report.sh`:
```
hashicorp/google newer version 8.1.0, current 7.46.0
hashicorp/google-beta newer version 8.1.0, current 7.46.0
terraform-google-modules/kubernetes-engine/google newer version 45.0.0, current 44.3.0
```

`common/aws/report.sh` (registry section):
```
hashicorp/aws newer version 6.63.0, current 6.61.0
hashicorp/tls newer version 4.4.0, current 4.3.0
terraform-aws-modules/efs/aws newer version 2.2.1, current 2.2.0
terraform-aws-modules/iam/aws newer version 6.8.1, current 6.8.0
terraform-aws-modules/vpc/aws newer version 6.7.2, current 6.7.0
```

Cross-checked every one of those against the old `registry.terraform.io/v2` lookup — **the two registries agree on all of them**:

| ref | OpenTofu | Terraform |
|---|---|---|
| hashicorp/aws | 6.63.0 | 6.63.0 |
| hashicorp/google | 8.1.0 | 8.1.0 |
| hashicorp/google-beta | 8.1.0 | 8.1.0 |
| terraform-aws-modules/vpc/aws | 6.7.2 | 6.7.2 |
| terraform-google-modules/kubernetes-engine/google | 45.0.0 | 45.0.0 |

`bash -n` passes on both scripts. The AWS script's trailing `aws ssm get-parameter` checks for the EKS AMI versions are untouched; they fail locally only because I have no AWS credentials, and they do not use any registry.

## Not changed here

- `common/sbom.py:228-230` still builds SPDX `downloadLocation` and `purl` values from `registry.terraform.io/providers/...`. Those are provenance URLs in the generated SBOM rather than a version lookup, so changing them changes SBOM output — worth doing, but deliberately not mixed into this PR.
- The two scripts have drifted from each other in ways this PR does not touch: the AWS provider `awk` joins multi-field version constraints while the Google one does not, the AWS provider loop skips `>=` constraints while the Google one does not, and the AWS Bottlerocket check prints `EKS AL2023_*` in its message instead of `EKS BOTTLEROCKET_*`. All pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
