### PR TITLE
update gcp-nuke

### DIFF
--- a/modules/google/kms/test/biz.yaml
+++ b/modules/google/kms/test/biz.yaml
@@ -1,4 +1,2 @@
-create_key_ring: false
-key_ring_name: "taivotest"
 key_rotation_period: 7776000s
 key_destroy_scheduled_duration: 86400s

--- a/modules/google/nuke.sh
+++ b/modules/google/nuke.sh
@@ -8,7 +8,7 @@ if [ "$GITHUB_ACTION" != "" ]; then
   docker run --rm \
     -e GOOGLE_APPLICATION_CREDENTIALS_JSON \
     -v "$SCRIPTPATH/google-nuke-config.yaml:/google-nuke-config.yaml:ro" \
-    taivox/gcp-nuke:v0.0.4 \
+    taivox/gcp-nuke:v0.0.5 \
     run --config /google-nuke-config.yaml --project-id entigo-infralib2 --no-prompt --prompt-delay 3 --quiet --no-dry-run --log-level trace
 
 else
@@ -16,7 +16,7 @@ else
   docker run --rm \
     -v ~/.config/gcloud:/home/gcp-nuke/.config/gcloud:ro \
     -v "$(pwd)/google-nuke-config.yaml:/google-nuke-config.yaml:ro" \
-    taivox/gcp-nuke:v0.0.4 \
+    taivox/gcp-nuke:v0.0.5 \
     run --config /google-nuke-config.yaml --project-id entigo-infralib2 --no-prompt --prompt-delay 3 --quiet --no-dry-run --log-level trace
 
 fi


### PR DESCRIPTION
Update gcp-nuke to the new version, which adds deletion support for SSLPolicy, KMSKeyRing, KMSKey, and KMSKeyVersion resources.

Update the google/kms biz test to create a new KMS key ring instead of using an existing one.