### PR TITLE
wireguard: wire the google pubkey route to google-gateway

### DIFF
--- a/modules/k8s/wireguard/README.md
+++ b/modules/k8s/wireguard/README.md
@@ -14,6 +14,83 @@ steps:
 
 ```
 
+## The public key endpoint, and why AWS and google differ
+
+The VPN itself is the same on both clouds: a `Service` of type `LoadBalancer`
+carrying UDP 51820 to the wireguard container.
+
+Alongside it the module serves the generated server public key over HTTPS, so
+that clients can fetch it without someone reading it out of the pod logs. That
+endpoint is the one thing this module cannot build the same way twice, and the
+two clouds end up quite far apart.
+
+### AWS: one load balancer, one hostname
+
+`values-aws.yaml` adds a second port to the wireguard `Service` through the
+chart's `service.extraPorts`, so the NLB carries both:
+
+| Listener | Protocol | Target |
+|---|---|---|
+| 51820 | UDP | wireguard container, 51820 |
+| 443 | TCP, TLS terminated | nginx pubkey sidecar, 8080 |
+
+Two things make this work, and neither has a google equivalent:
+
+- The NLB **terminates TLS**. `aws-load-balancer-ssl-ports: "443"` plus the ACM
+  certificate from `agent_input_aws.yaml` mean the sidecar only ever serves
+  plain HTTP on 8080.
+- It is **one load balancer, so one IP, so one A record**. The VPN and the
+  public key live on the same hostname,
+  `<module name>.<route53 pub_domain>`, on different ports.
+
+### Google: a route on the shared gateway, on its own hostname
+
+Google gets the same nginx sidecar, but reaches it through an `HTTPRoute` on the
+external gateway published by the `google-gateway` module, with a `Service` and
+a `HealthCheckPolicy` of its own under `templates/google/`. The hostname is
+`<module name>-pubkey.<dns pub_domain>`, separate from the VPN hostname.
+
+It is worth writing down why, because the obvious question is why google does
+not simply copy AWS:
+
+1. **A passthrough load balancer terminates no TLS.** Google's external
+   passthrough Network Load Balancer forwards traffic without decrypting it and
+   holds no certificates — only the Application and proxy Network Load
+   Balancers do. There is no `ssl-cert` equivalent to hang off the wireguard
+   `Service`. The TLS for this host comes from the gateway's Certificate
+   Manager map instead.
+2. **The addresses cannot be shared.** The external gateway class
+   `gke-l7-global-external-managed` takes a **global** address; a regional
+   passthrough Network Load Balancer takes a **regional** one. They cannot be
+   the same address resource, so the gateway and the wireguard load balancer
+   always answer on different IPs — which is why the public key needs a
+   hostname of its own rather than a second port on the VPN hostname.
+
+Historically there was a third reason: a google `Service` of type
+`LoadBalancer` could not carry TCP and UDP at once. **That one has expired.**
+GKE supports mixed protocol `LoadBalancer` Services via
+`spec.loadBalancerClass: networking.gke.io/l4-regional-external`, GA from
+1.36.2-gke.1498000 and available external/IPv4-only from 1.34.1-gke.2190000.
+Do not treat it as the blocker any more — the two reasons above are what keep
+the designs apart, and neither is fixed by putting both protocols on one
+`Service`.
+
+Terminating TLS inside the nginx sidecar would collapse the difference, at the
+cost of an ACME issuer and in-pod certificate renewal. cert-manager is not a
+module in this repository today, so that is not on the table.
+
+### What this means when reading the module
+
+- `agent_input.yaml` holds everything both clouds share, including the sidecar,
+  its volume and the VPN hostname annotations.
+- `agent_input_aws.yaml` is only the ACM certificate.
+- `agent_input_google.yaml` is only the pubkey hostname and the gateway to
+  attach the route to.
+- `global.gateway` and `global.pubkeyHostname` are declared in `values.yaml`
+  but filled on google alone. On AWS they stay empty and nothing reads them,
+  because `templates/google/` is gated on `global.cloudProvider`.
+
+## Client configuration
 
 dns_policy_vpc_ids must be set in google/dns to resolve DNS names from private DNS zones
 

--- a/modules/k8s/wireguard/agent_input.yaml
+++ b/modules/k8s/wireguard/agent_input.yaml
@@ -1,4 +1,9 @@
 wireguard:
+  service:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: "{{ .module.name }}.{{ .toptout.route53.pub_domain | .toptout.dns.pub_domain | required }}"
+      # Not consumed by the load balancer, agent.yaml reads it back as vpn_host
+      hostname: "{{ .module.name }}.{{ .toptout.route53.pub_domain | .toptout.dns.pub_domain | required }}"
   image:
     repository: '{{ .toptout.ecr-proxy.ghcr_registry | .toptout.gar-proxy.ghcr_registry | "ghcr.io" }}/bryopsida/wireguard'
   keygenJob:
@@ -11,3 +16,28 @@ wireguard:
   healthSideCar:
     image:
       repository: '{{ .toptout.ecr-proxy.ghcr_registry | .toptout.gar-proxy.ghcr_registry | "ghcr.io" }}/bryopsida/http-healthcheck-sidecar'
+  # Serves the generated public key. On AWS it is reached through the extra
+  # TCP 443 port of the wireguard NLB, on google through templates/google.
+  extraSideCars:
+  - name: pubkey
+    image: '{{ .toptout.ecr-proxy.hub_registry | .toptout.gar-proxy.hub_registry | "docker.io" }}/nginxinc/nginx-unprivileged:1.29-alpine'
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+    volumeMounts:
+    - name: pubkey
+      mountPath: /usr/share/nginx/html/index.html
+      subPath: publickey
+    resources:
+      requests:
+        cpu: 1m
+        memory: 1Mi
+        ephemeral-storage: 4Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+        ephemeral-storage: 128Mi
+  volumes:
+  - name: pubkey
+    secret:
+      secretName: '{{ .module.name }}-wg-generated-public'

--- a/modules/k8s/wireguard/agent_input_aws.yaml
+++ b/modules/k8s/wireguard/agent_input_aws.yaml
@@ -1,26 +1,5 @@
 wireguard:
   service:
-    annotations: 
-      external-dns.alpha.kubernetes.io/hostname: "{{ .module.name }}.{{ .toutput.route53.pub_domain }}"
-      hostname: "{{ .module.name }}.{{ .toutput.route53.pub_domain }}"
+    annotations:
+      # The NLB terminates TLS for the pubkey port declared in values-aws.yaml
       service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{{ .toutput.route53.pub_cert_arn }}"
-  extraSideCars:
-  - name: pubkey
-    image: '{{ .toptout.ecr-proxy.hub_registry | "docker.io" }}/nginxinc/nginx-unprivileged:1.29-alpine'
-    volumeMounts:
-    - name: pubkey
-      mountPath: /usr/share/nginx/html/index.html
-      subPath: publickey
-    resources:
-      requests:
-        cpu: 1m
-        memory: 1Mi
-        ephemeral-storage: 4Mi
-      limits:
-        cpu: 100m
-        memory: 64Mi
-        ephemeral-storage: 128Mi
-  volumes:
-  - name: pubkey
-    secret:
-      secretName: '{{ .module.name }}-wg-generated-public'

--- a/modules/k8s/wireguard/agent_input_google.yaml
+++ b/modules/k8s/wireguard/agent_input_google.yaml
@@ -1,7 +1,7 @@
 global:
   # Own hostname, because the wireguard load balancer cannot serve this
-  # endpoint on google. See the comment in values.yaml.
+  # endpoint on google. See README.md.
   pubkeyHostname: "{{ .module.name }}-pubkey.{{ .toutput.dns.pub_domain }}"
   gateway:
-    name: '{{ .toptin.google-gateway.global.externalGateway | required }}'
-    namespace: '{{ .toptmodule.google-gateway | required }}'
+    name: "{{ .tinput.google-gateway.global.externalGateway }}"
+    namespace: "{{ .tmodule.google-gateway }}"

--- a/modules/k8s/wireguard/agent_input_google.yaml
+++ b/modules/k8s/wireguard/agent_input_google.yaml
@@ -1,32 +1,7 @@
 global:
-  google:
-    hostname: "{{ .module.name }}-pubkey.{{ .toutput.dns.pub_domain }}"
-
-wireguard:
-  service:
-    annotations:
-      external-dns.alpha.kubernetes.io/hostname: "{{ .module.name }}.{{ .toutput.dns.pub_domain }}"
-      hostname: "{{ .module.name }}.{{ .toutput.dns.pub_domain }}"
-  extraSideCars:
-    - name: pubkey
-      image: '{{ .toptout.gar-proxy.hub_registry | "docker.io" }}/nginxinc/nginx-unprivileged:1.29-alpine'
-      ports:
-        - containerPort: 8080
-          protocol: TCP
-      volumeMounts:
-        - name: pubkey
-          mountPath: /usr/share/nginx/html/index.html
-          subPath: publickey
-      resources:
-        requests:
-          cpu: 1m
-          memory: 1Mi
-          ephemeral-storage: 4Mi
-        limits:
-          cpu: 100m
-          memory: 64Mi
-          ephemeral-storage: 128Mi
-  volumes:
-    - name: pubkey
-      secret:
-        secretName: "{{ .module.name }}-wg-generated-public"
+  # Own hostname, because the wireguard load balancer cannot serve this
+  # endpoint on google. See the comment in values.yaml.
+  pubkeyHostname: "{{ .module.name }}-pubkey.{{ .toutput.dns.pub_domain }}"
+  gateway:
+    name: '{{ .toptin.google-gateway.global.externalGateway | required }}'
+    namespace: '{{ .toptmodule.google-gateway | required }}'

--- a/modules/k8s/wireguard/templates/google/httpRoute.yaml
+++ b/modules/k8s/wireguard/templates/google/httpRoute.yaml
@@ -1,17 +1,23 @@
 {{- if eq .Values.global.cloudProvider "google" }}
-
+# Public key download endpoint. AWS serves it from the extra TCP 443 port of
+# the wireguard NLB, which terminates TLS with an ACM certificate. Google's
+# passthrough load balancer terminates no TLS and takes a regional address
+# while the external gateway is global, so neither the address nor the
+# hostname can be shared and the endpoint gets a route of its own.
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
-apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: {{ .Release.Name }}-pubkey
+  namespace: {{ .Release.Namespace }}
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: {{ .Values.global.google.gateway.name }}
+      name: {{ .Values.global.gateway.name }}
+      namespace: {{ .Values.global.gateway.namespace }}
       sectionName: https
-      namespace: {{ .Values.global.google.gateway.namespace }}
-  hostnames: [ {{ .Values.global.google.hostname }} ]
+  hostnames:
+    - {{ .Values.global.pubkeyHostname | quote }}
   rules:
     - backendRefs:
         - group: ''
@@ -23,5 +29,4 @@ spec:
         - path:
             type: PathPrefix
             value: /
-
 {{- end }}

--- a/modules/k8s/wireguard/templates/google/httpRoute.yaml
+++ b/modules/k8s/wireguard/templates/google/httpRoute.yaml
@@ -1,9 +1,8 @@
 {{- if eq .Values.global.cloudProvider "google" }}
-# Public key download endpoint. AWS serves it from the extra TCP 443 port of
-# the wireguard NLB, which terminates TLS with an ACM certificate. Google's
-# passthrough load balancer terminates no TLS and takes a regional address
-# while the external gateway is global, so neither the address nor the
-# hostname can be shared and the endpoint gets a route of its own.
+# Public key download endpoint, google only. AWS serves it from an extra port
+# of the wireguard NLB, which terminates TLS itself. Google's passthrough load
+# balancer terminates no TLS and cannot share the global gateway's address, so
+# the endpoint gets a route and a hostname of its own. See README.md.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/modules/k8s/wireguard/values-google.yaml
+++ b/modules/k8s/wireguard/values-google.yaml
@@ -1,8 +1,2 @@
 global:
   cloudProvider: "google"
-  google:
-    projectID: ""
-    hostname: ""
-    gateway:
-      name: google-gateway-external
-      namespace: google-gateway

--- a/modules/k8s/wireguard/values.yaml
+++ b/modules/k8s/wireguard/values.yaml
@@ -1,12 +1,9 @@
 global:
   cloudProvider: ""
 
-  # Public key download route, google only. On AWS the public key is served on
-  # an extra TCP 443 port of the wireguard NLB, which terminates TLS with an
-  # ACM certificate. Google's passthrough load balancer cannot terminate TLS,
-  # and it takes a regional address while the external gateway is global, so
-  # the two can share neither an address nor a hostname. All three are filled
-  # from agent_input_google.yaml, from google-gateway.
+  # Public key download route, google only, filled from agent_input_google.yaml.
+  # On AWS the public key is served from an extra port of the wireguard NLB
+  # instead and these stay empty. README.md explains why the two differ.
   pubkeyHostname: ""
   gateway:
     name: ""

--- a/modules/k8s/wireguard/values.yaml
+++ b/modules/k8s/wireguard/values.yaml
@@ -1,6 +1,17 @@
 global:
   cloudProvider: ""
 
+  # Public key download route, google only. On AWS the public key is served on
+  # an extra TCP 443 port of the wireguard NLB, which terminates TLS with an
+  # ACM certificate. Google's passthrough load balancer cannot terminate TLS,
+  # and it takes a regional address while the external gateway is global, so
+  # the two can share neither an address nor a hostname. All three are filled
+  # from agent_input_google.yaml, from google-gateway.
+  pubkeyHostname: ""
+  gateway:
+    name: ""
+    namespace: ""
+
 wireguard:
   wireguard:
     serverAddress: ""


### PR DESCRIPTION
Last module still carrying a `templates/google/httpRoute.yaml` from before the gateway rework.

## Why the google exception stays

I checked whether google could now share one `Service` type `LoadBalancer` the way AWS does. The AWS service is mixed protocol — `wg` UDP 51820 from the chart plus `pubkey` TCP 443 from `values-aws.yaml` — on one NLB, one IP, one hostname.

**Mixed protocol is no longer the blocker.** GKE supports it via `spec.loadBalancerClass: networking.gke.io/l4-regional-external`, GA from 1.36.2-gke.1498000 and external/IPv4-only from 1.34.1-gke.2190000 (our `modules/google/gke` defaults to the `1.35.` series). The chart already exposes `service.loadBalancerClass`.

**Two other things still block it:**

1. A passthrough Network Load Balancer terminates no TLS and holds no certificates — only Application and Proxy Network Load Balancers do. Our google TLS for this host comes from the gateway's Certificate Manager map. On the NLB the endpoint could only be plain HTTP.
2. `gke-l7-global-external-managed` takes a **global** address; a regional passthrough NLB takes a **regional** one. They cannot be the same address resource, so the gateway and the wireguard NLB always have different IPs — which is why the separate `-pubkey` hostname is structural, not incidental.

Terminating TLS inside the nginx sidecar would work in principle but needs cert-manager, which is not a module in this repo. So the route stays, and the reasoning is now a comment next to it instead of folklore.

## What changed

- **Gateway from the module, not hardcoded.** `values-google.yaml` pinned `google-gateway-external` / `google-gateway`. `google-gateway/values.yaml` warns those names track the module name, so deploying it under any other name silently attached this route to a nonexistent Gateway. Now `{{ .tinput.google-gateway.global.externalGateway }}` and `{{ .tmodule.google-gateway }}` — a one-element optional chain ending in `required` is just a required tag spelled the long way.
- **Values reshaped** to `global.gateway.{name,namespace}` + `global.pubkeyHostname`, matching mimir/kiali/istio-gateway. Declared in `values.yaml` per the authoring guide. Named `pubkeyHostname` rather than `hostname` because this module has two hostnames and this is the one that is *not* the VPN endpoint.
- **Deduplicated the agent inputs.** Moved to `agent_input.yaml`: the two hostname annotations (one `route53 | dns | required` chain), the pubkey sidecar (registry now the same `ecr-proxy | gar-proxy | "docker.io"` chain as the other images in that file), and the pubkey volume, which was already byte-identical. `agent_input_aws.yaml` keeps only the ACM cert. `agent_input_google.yaml` keeps only the route wiring.
- **Route modernised:** `gateway.networking.k8s.io/v1beta1` → `v1`, added `metadata.namespace`, quoted the hostname.
- **Removed** `global.google.projectID`, read by nothing.

## Testing

`helm lint --strict` passes. Docker was unavailable locally so kube-score did not run, but **the render with `values.yaml` alone is byte-identical to main's**, so the static suite and kube-score cannot change.

Rendered both cloud paths with simulated agent inputs:
- **google** — HTTPRoute is `v1`, namespaced, hostname resolves, gateway comes from the inputs; pubkey `Service` and `HealthCheckPolicy` unchanged.
- **aws** — all ten service annotations merge as before (seven static, two from `agent_input.yaml`, the cert from `agent_input_aws.yaml`), mixed-protocol ports intact, sidecar and volume present.

Added `README.md`, which writes down why the two clouds differ here — including that mixed-protocol `LoadBalancer` Services, the reason usually given, are supported on GKE now and are *not* what keeps the designs apart. With the reasoning in one place, `values.yaml` and the route template stop repeating it and just point at it.

No new test envs, per review. `templates/aws/placeholder.yaml` left alone.

## Notes for the reviewer

- One behaviour change on AWS: the pubkey sidecar now declares `containerPort: 8080`, which the google copy always had. Informational only, costs one pod rollout.
- `values-aws.yaml` is untouched. The `healthcheck-path` next to `healthcheck-protocol: TCP` is dead config (the controller drops the path for TCP), but the check itself is healthy, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)