### PR TITLE
aws-alb: fix Gatway typo in the README

### DIFF
--- a/modules/k8s/aws-alb/README.md
+++ b/modules/k8s/aws-alb/README.md
@@ -142,7 +142,7 @@ Set `routingResources` to `both` so the module creates the `GatewayClass` and
             routingResources: "both"
 ```
 
-You might also want to specify what Gateways to create. For example if you do not use external `Gatway` and use a service `Gateway` then your configuration would be as follows:
+You might also want to specify what Gateways to create. For example if you do not use external `Gateway` and use a service `Gateway` then your configuration would be as follows:
 ```yaml
       - name: aws-alb
         source: aws-alb


### PR DESCRIPTION
One-character fix in `modules/k8s/aws-alb/README.md:145`: `` `Gatway` `` → `` `Gateway` ``.

The sentence already uses `` `Gateway` `` correctly twice around it, so this was just a slip.

Found while sweeping every hand-written `.md`/`.tf`/`.yaml` under `modules/` (excluding vendored charts and CRDs) for common misspellings — this was the only hit in the whole tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)