### PR TITLE
k8s: only create TargetGroupConfigurations when a route exists

### DIFF
--- a/modules/k8s/argocd/templates/aws/targetGroupConfiguration.yaml
+++ b/modules/k8s/argocd/templates/aws/targetGroupConfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.global.cloudProvider "aws") .Values.argocd.server.grpcroute.enabled }}
+{{- if and (eq .Values.global.cloudProvider "aws") (or .Values.argocd.server.httproute.enabled .Values.argocd.server.grpcroute.enabled) }}
 apiVersion: gateway.k8s.aws/v1beta1
 kind: TargetGroupConfiguration
 metadata:
@@ -12,6 +12,7 @@ spec:
     protocol: HTTPS
     healthCheckConfig:
       healthCheckPath: /healthz
+  {{- if .Values.argocd.server.grpcroute.enabled }}
   routeConfigurations:
     - routeIdentifier:
         kind: GRPCRoute
@@ -24,4 +25,5 @@ spec:
           healthCheckPath: /
           matcher:
             grpcCode: "12"
+  {{- end }}
 {{- end }}

--- a/modules/k8s/grafana/templates/aws/targetGroupConfiguration.yaml
+++ b/modules/k8s/grafana/templates/aws/targetGroupConfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.cloudProvider "aws" }}
+{{- if and (eq .Values.global.cloudProvider "aws") .Values.grafana.route.main.enabled }}
 apiVersion: gateway.k8s.aws/v1beta1
 kind: TargetGroupConfiguration
 metadata:

--- a/modules/k8s/harbor/templates/aws/targetGroupConfiguration.yaml
+++ b/modules/k8s/harbor/templates/aws/targetGroupConfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.cloudProvider "aws" }}
+{{- if and (eq .Values.global.cloudProvider "aws") (eq .Values.harbor.expose.type "route") }}
 apiVersion: gateway.k8s.aws/v1beta1
 kind: TargetGroupConfiguration
 metadata:

--- a/modules/k8s/kiali/templates/aws/targetGroupConfiguration.yaml
+++ b/modules/k8s/kiali/templates/aws/targetGroupConfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.cloudProvider "aws" }}
+{{- if and (eq .Values.global.cloudProvider "aws") .Values.global.createRoute }}
 apiVersion: gateway.k8s.aws/v1beta1
 kind: TargetGroupConfiguration
 metadata:

--- a/modules/k8s/mimir/templates/aws/targetGroupConfiguration.yaml
+++ b/modules/k8s/mimir/templates/aws/targetGroupConfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.cloudProvider "aws" }}
+{{- if and (eq .Values.global.cloudProvider "aws") .Values.global.createRoute }}
 apiVersion: gateway.k8s.aws/v1beta1
 kind: TargetGroupConfiguration
 metadata:

--- a/modules/k8s/prometheus/templates/aws/targetGroupConfiguration.yaml
+++ b/modules/k8s/prometheus/templates/aws/targetGroupConfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.cloudProvider "aws" }}
+{{- if and (eq .Values.global.cloudProvider "aws") .Values.prometheus.server.route.main.enabled }}
 apiVersion: gateway.k8s.aws/v1beta1
 kind: TargetGroupConfiguration
 metadata:


### PR DESCRIPTION
`TargetGroupConfiguration` is a **Gateway API only** resource (`gateway.k8s.aws/v1beta1`) — Ingress target groups are configured from `alb.ingress.kubernetes.io/*` annotations instead. So with `aws-alb` in its default `routingResources: "ingress"` mode, every one of these objects was being applied for nothing.

It also matters for ordering: `aws-alb` owns the CRD (`albGatewayCrds.yaml`), so a module that renders a `TargetGroupConfiguration` before `aws-alb` has synced cannot be applied at all. `argocd` already carried a gate for exactly that reason — it is installed ahead of `aws-alb` on a fresh cluster. Worth noting `SkipDryRunOnMissingResource=true` does *not* rescue this case: it skips the dry run, but the real apply still fails while the CRD is genuinely absent.

## The gates

`loki`, `istio-gateway` and `saml-proxy` were already gated and are untouched. The five that weren't, gated on whatever each chart uses to decide whether it renders a route — which is not uniform:

| Module | Gate added |
|---|---|
| grafana | `.Values.grafana.route.main.enabled` |
| prometheus | `.Values.prometheus.server.route.main.enabled` |
| harbor | `eq .Values.harbor.expose.type "route"` (enum, not a bool) |
| mimir | `.Values.global.createRoute` |
| kiali | `.Values.global.createRoute` |

Helm's `and` does not short-circuit, so I checked that each key has a route-off default in the upstream chart values rather than relying on the cloud gate to protect it: `grafana.route.main.enabled: false`, `prometheus.server.route.main.enabled: false`, `harbor.expose.type: ingress`, and `global.createRoute: false` in our own `values.yaml` for mimir/kiali. Nothing here can nil-pointer.

## argocd was too narrow, not missing

Its single object configures **both** target groups — the HTTPRoute (web UI) one via `defaultConfiguration` and the GRPCRoute one via `routeConfigurations` — but it was gated on `grpcroute.enabled` alone. An install with the web UI route on and gRPC off silently lost the HTTPRoute health-check settings.

Widened to either route, and the GRPCRoute reference now renders only when that route actually exists, since a `routeIdentifier` pointing at a route the chart never renders fails silently:

| httproute | grpcroute | TGC | routeConfigurations |
|---|---|---|---|
| true | true | 1 | 1 |
| true | false | 1 | 0 |
| false | true | 1 | 1 |
| false | false | 0 | 0 |

## Testing

`helm lint --strict` passes on all six touched modules.

Gate matrix, rendered per module with `values.yaml` + `values-aws.yaml` + a route-on / route-off override — every module goes 1→0 (harbor 2→0, it renders core and portal):

| | grafana | prometheus | harbor | mimir | kiali | argocd | loki | istio-gateway | saml-proxy |
|---|---|---|---|---|---|---|---|---|---|
| route on | 1 | 1 | 2 | 1 | 1 | 1 | 1 | 1 | 1 |
| ingress only | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

Static renders (`values.yaml` only, as CI runs them) produce an **identical resource set** to main for all six modules, with zero `TargetGroupConfiguration`s before and after — `cloudProvider` is empty there, so these templates never rendered in the static suite anyway. Line-level diffs show only the per-run random secrets those charts generate (grafana admin password, harbor TLS material, kiali signing key), which differ on every `helm template` invocation regardless of this change.

## Note

This does not conflict with the "`TargetGroupConfiguration` values are inlined, never set from gitops values" convention — the settings stay hardcoded in the template. The gate is template-internal and invisible to gitops values; it only asks whether the route these settings describe exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)