### PR TITLE
saml-proxy: bring the route values into the shape the other modules use

### DIFF
--- a/modules/k8s/saml-proxy/agent_input_aws.yaml
+++ b/modules/k8s/saml-proxy/agent_input_aws.yaml
@@ -1,17 +1,14 @@
-image: 
+image:
   registry: '{{ .toptout.ecr-proxy.hub_registry | "docker.io" }}/priitrent/saml-proxy'
-
-ingress:
-  hostName: "{{ .module.name }}.{{ .toutput.route53.pub_domain }}"
 
 secretStore:
   name: "{{ .tmodule.external-secrets }}"
 
 global:
+  hostname: "{{ .module.name }}.{{ .toutput.route53.pub_domain }}"
+  createRoute: "{{ .tinput.aws-alb.global.createRoute }}"
+  gateway:
+    name: "{{ .tinput.aws-alb.global.externalGateway }}"
+    namespace: "{{ .tmodule.aws-alb }}"
   aws:
-    createIngress:  "{{ .tinput.aws-alb.global.createIngress }}"
-    createRoute: "{{ .tinput.aws-alb.global.createRoute }}"
-    gateway:
-      name: "{{ .tinput.aws-alb.global.externalGateway }}"
-      namespace: "{{ .tmodule.aws-alb }}"
-    hostname: "{{ .module.name }}.{{ .toutput.route53.pub_domain }}"
+    createIngress: "{{ .tinput.aws-alb.global.createIngress }}"

--- a/modules/k8s/saml-proxy/templates/httpRoute.yaml
+++ b/modules/k8s/saml-proxy/templates/httpRoute.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.global.cloudProvider "aws") .Values.global.aws.createRoute }}
+{{- if and (eq .Values.global.cloudProvider "aws") .Values.global.createRoute }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -8,10 +8,11 @@ spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: {{ .Values.global.aws.gateway.name }}
-      namespace: {{ .Values.global.aws.gateway.namespace }}
+      name: {{ .Values.global.gateway.name }}
+      namespace: {{ .Values.global.gateway.namespace }}
       sectionName: https
-  hostnames: [ {{ .Values.global.aws.hostname }} ]
+  hostnames:
+    - {{ .Values.global.hostname | quote }}
   rules:
     - backendRefs:
         - group: ''

--- a/modules/k8s/saml-proxy/templates/ingress.yaml
+++ b/modules/k8s/saml-proxy/templates/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ .Release.Name }}
 spec:
   rules:
-  - host: '{{ .Values.ingress.hostName }}'
+  - host: '{{ .Values.global.hostname }}'
     http:
       paths:
       - backend:

--- a/modules/k8s/saml-proxy/templates/targetGroupConfiguration.yaml
+++ b/modules/k8s/saml-proxy/templates/targetGroupConfiguration.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.global.cloudProvider "aws") .Values.global.aws.createRoute }}
+{{- if and (eq .Values.global.cloudProvider "aws") .Values.global.createRoute }}
 apiVersion: gateway.k8s.aws/v1beta1
 kind: TargetGroupConfiguration
 metadata:

--- a/modules/k8s/saml-proxy/values-aws.yaml
+++ b/modules/k8s/saml-proxy/values-aws.yaml
@@ -1,0 +1,2 @@
+global:
+  cloudProvider: "aws"

--- a/modules/k8s/saml-proxy/values.yaml
+++ b/modules/k8s/saml-proxy/values.yaml
@@ -1,12 +1,20 @@
 global:
-  cloudProvider: aws
+  # Route target. All three are filled from agent_input_aws.yaml, from aws-alb.
+  createRoute: false
+  hostname: ""
+  gateway:
+    name: ""
+    namespace: ""
+
+  # Platform prefix, used for the session cookie name.
+  prefix: ""
+
   aws:
+    # Ingress is the AWS only alternative to the route, also from aws-alb.
+    createIngress: true
     scheme: internet-facing
     groupName: external
     additionalIngressAnnotations: {}
-
-ingress:
-  hostName: ""
 
 targetService: ""
 


### PR DESCRIPTION
The last module still on the pre-rework value shape. It kept the route target under `global.aws` and declared none of it — six keys the templates read existed only in `agent_input_aws.yaml`, so `helm template` with `values.yaml` alone silently rendered neither the ingress nor the route, and nobody reading `values.yaml` could discover the knobs.

## What changed

| Before | After |
|---|---|
| `global.aws.createRoute` | `global.createRoute` |
| `global.aws.gateway.{name,namespace}` | `global.gateway.{name,namespace}` |
| `global.aws.hostname` **and** `ingress.hostName` | `global.hostname` |
| `global.aws.createIngress` | unchanged, but now declared |
| `global.prefix` | now declared |
| `cloudProvider: aws` in `values.yaml` | new `values-aws.yaml` |

Top-level `createRoute` / `hostname` / `gateway` matches kiali, mimir, istio-gateway and wireguard. `createIngress` stays nested under `global.aws` — an ALB Ingress genuinely has no counterpart on another cloud — and now defaults to the same value `aws-alb` defaults to (`true`, with `createRoute: false`).

`ingress.hostName` and `global.aws.hostname` were two keys carrying the **identical** agent expression, one per template, both set from `route53.pub_domain`. Collapsed into one.

`cloudProvider` moves to `values-aws.yaml` because the authoring guide asks for it there and nowhere else; `cluster-autoscaler` and `entigo-portal-agent` already do this for AWS-only modules. This changes nothing at render time — the templates gating on `cloudProvider` also gate on a route or ingress flag that was already falsy in the static tests.

Also quoted the route hostname and gave it list form instead of the inline `[ ... ]`, matching the other route templates.

**Unlike wireguard, the gateway here was already resolved from the module** (`.tinput.aws-alb.global.externalGateway` / `.tmodule.aws-alb`) rather than hardcoded, so there was no rename bug to fix. Only the value shape and the missing declarations were the problem.

## Testing

`helm lint --strict` passes. The undeclared-key scan is now clean for this module (it was the worst offender at six keys).

Rendered both modes with `values.yaml` + `values-aws.yaml` + agent-equivalent inputs:

| Mode | Rendered |
|---|---|
| `createRoute: true`, `createIngress: false` | Deployment, ExternalSecret, Service, **HTTPRoute**, **TargetGroupConfiguration** — hostname and gateway resolve correctly |
| `createRoute: false`, `createIngress: true` | Deployment, ExternalSecret, Service, **Ingress** — host resolves correctly |

The TGC gate stays on `createRoute`, which is consistent with #1709.

The static render (`values.yaml` only, as CI runs it) is **byte-identical to main**.

## On `global.prefix`

`templates/deployment.yaml:77` sets the session cookie name from `.Values.global.prefix`, which no file in this repo sets. That needs no agent input: the agent populates it for every `argocd-apps` module unconditionally, in `service/update.go:1371`:

```go
prefix := fmt.Sprintf("%s-%s-%s", u.resources.GetCloudPrefix(), step.Name, module.Name)
err := util.SetChildStringValue(inputs, prefix, false, "global", "prefix")
```

So the live value is `<cloudPrefix>-<step>-<module>`, and `overwrite: false` means a platform's own `inputs:` still wins. It is declared here as `""` purely so the key is discoverable and the static render works — exactly what the authoring guide asks for keys whose real value only ever arrives from the agent. No behaviour change, and nothing to wire up.

## Note

`ingress.hostName` is the one rename that is technically breaking: a platform overriding it via `inputs:` would need to switch to `global.hostname`. `agent_input_aws.yaml` always set it from `route53.pub_domain`, so an override seems unlikely, but worth a look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)