### PR TITLE
docs: explain the global.prefix the agent sets on its own

### DIFF
--- a/modules/k8s/README.md
+++ b/modules/k8s/README.md
@@ -256,21 +256,31 @@ test-apps-saml-proxy
 
 That makes it the right thing to reach for whenever a module needs a name that
 is stable for one installation and distinct from every other one — a cookie
-name, a resource name, a label value.
+name, a label value, an identifier in a shared external system.
 
-Two rules follow from how it is set:
+Two things follow from how it is set:
 
 - **Declare `prefix: ""` in `values.yaml`** like any other key the templates
   read. The real value always comes from the agent, but the declaration is what
   keeps the static tests rendering and what tells a reader the key exists.
-- **Do not set it yourself.** The agent fills it in only when nothing else
-  already has. `agent_input.yaml`, `agent_input_<cloud>.yaml` and the step's
-  `inputs:` are merged first, in that order, and the prefix is written only if
-  `global.prefix` is still missing afterwards. So putting
-  `prefix: "{{ .config.prefix }}"` in an agent input adds nothing — it replaces
-  the agent's value with a less unique one, dropping the step and module that
-  distinguish it. A couple of modules still carry such a line from earlier
-  work; nothing reads `global.prefix` in them.
+- **You can override it, and sometimes you want to.** The agent fills the key in
+  only when nothing else already has: `agent_input.yaml`,
+  `agent_input_<cloud>.yaml` and the step's `inputs:` are merged first, in that
+  order, and the prefix is written only if `global.prefix` is still missing
+  afterwards. So `prefix: "{{ .config.prefix }}"` in an agent input replaces it
+  with the bare environment identifier, dropping the step and module. That is
+  the right call whenever the name only has to be unique per environment rather
+  than per module — a bucket name, for instance, where `dev-loki` says
+  everything that `dev-apps-loki` would. Just remember that the override
+  applies to the whole module, so everything in it that reads `global.prefix`
+  gets the shorter value.
+
+Note that `.config.prefix` and `global.prefix` are not the same thing.
+`.config.prefix` is the environment identifier on its own, and is what most
+modules compose bucket names and IAM resource names out of. `global.prefix` is
+the longer per module value above. Reach for the tag when you are building a
+name, and for `global.prefix` when you want the identity of this one module in
+this one environment.
 
 The code is `updateArgoCDFiles` in the agent's `service/update.go`.
 

--- a/modules/k8s/README.md
+++ b/modules/k8s/README.md
@@ -282,8 +282,6 @@ the longer per module value above. Reach for the tag when you are building a
 name, and for `global.prefix` when you want the identity of this one module in
 this one environment.
 
-The code is `updateArgoCDFiles` in the agent's `service/update.go`.
-
 ## Cloud specific resources
 
 Resources this repository owns live in `templates/`. A module that supports more

--- a/modules/k8s/README.md
+++ b/modules/k8s/README.md
@@ -156,7 +156,7 @@ The tags used most in these modules:
 | Tag | Resolves to |
 |---|---|
 | `.module.name` | this module's name |
-| `.config.prefix` | the platform prefix |
+| `.config.prefix` | the platform prefix, which identifies the environment |
 | `.toutput.<source>.<key>` | a Terraform output of the module with that source |
 | `.toptout.<source>.<key>` | the same, empty string when absent |
 | `.tinput.<source>.<path>` | a value from another module in this step |
@@ -233,6 +233,46 @@ Two things do not chain and still need splitting or restructuring:
   the two copies in step.
 - **Whole blocks that only exist on one cloud.** Chain the values, not the
   block.
+
+### `global.prefix` arrives on its own
+
+One value reaches every module without the module asking for it. While
+generating the `Application`, the agent sets `global.prefix` on every
+`argocd-apps` module, whether or not it appears in any `agent_input` file:
+
+```
+<platform prefix>-<step name>-<module name>
+```
+
+The platform prefix is the environment identifier — the `prefix` the platform
+is deployed under, typically something short like `dev` or `test`. Step names
+are normally the same in every environment, so the platform prefix is the part
+that makes the value differ between them:
+
+```
+dev-apps-saml-proxy
+test-apps-saml-proxy
+```
+
+That makes it the right thing to reach for whenever a module needs a name that
+is stable for one installation and distinct from every other one — a cookie
+name, a resource name, a label value.
+
+Two rules follow from how it is set:
+
+- **Declare `prefix: ""` in `values.yaml`** like any other key the templates
+  read. The real value always comes from the agent, but the declaration is what
+  keeps the static tests rendering and what tells a reader the key exists.
+- **Do not set it yourself.** The agent fills it in only when nothing else
+  already has. `agent_input.yaml`, `agent_input_<cloud>.yaml` and the step's
+  `inputs:` are merged first, in that order, and the prefix is written only if
+  `global.prefix` is still missing afterwards. So putting
+  `prefix: "{{ .config.prefix }}"` in an agent input adds nothing — it replaces
+  the agent's value with a less unique one, dropping the step and module that
+  distinguish it. A couple of modules still carry such a line from earlier
+  work; nothing reads `global.prefix` in them.
+
+The code is `updateArgoCDFiles` in the agent's `service/update.go`.
 
 ## Cloud specific resources
 


### PR DESCRIPTION
Adds a `### global.prefix arrives on its own` subsection to the `modules/k8s` authoring guide, at the end of **Agent inputs**.

Worth documenting because the current state is misleading: nothing in this repository sets `global.prefix`, so `saml-proxy/templates/deployment.yaml:77` reading it looks like a bug — and the obvious "fix" of chaining `{{ .config.prefix }}` into an agent input would silently change its meaning. I nearly did that in #1710.

## What it says

The agent sets it on every `argocd-apps` module while generating the `Application`:

```
<platform prefix>-<step name>-<module name>
```

The platform prefix is the environment identifier — `dev`, `test` — and step names are normally identical across environments, so the platform prefix is the part that tells two environments apart:

```
dev-apps-saml-proxy
test-apps-saml-proxy
```

Which makes it the right thing to reach for when a module needs a name that is stable for one installation and distinct from every other one: a cookie name, a label value, an identifier in a shared external system.

Then two things that follow from *how* it is set:

- **Declare `prefix: ""` in `values.yaml`**, like any other key the templates read.
- **You can override it, and sometimes you want to.** The agent fills the key in only when nothing else already has, so `prefix: "{{ .config.prefix }}"` in an agent input gives you the bare environment identifier without the step and module — the right call when a name only has to be unique per environment. A bucket is the obvious case: `dev-loki` carries as much information as `dev-apps-loki` would.

Plus a short note that `.config.prefix` and `global.prefix` are not the same thing — the tag is what most modules compose bucket and IAM names out of, `global.prefix` is the longer per-module identity.

Also clarified the `.config.prefix` row in the replacement-tag table to say it identifies the environment.

## Verified against the agent, not assumed

`getModuleInputs` (`service/update.go`) merges `agent_input.yaml` → `agent_input_<cloud>.yaml` → the step's `inputs:`, in that order. `updateArgoCDFiles` then runs:

```go
prefix := fmt.Sprintf("%s-%s-%s", u.resources.GetCloudPrefix(), step.Name, module.Name)
err := util.SetChildStringValue(inputs, prefix, false, "global", "prefix")
```

`overwrite` is `false` and the merge has already happened, so a `prefix:` written in any of those three layers wins over the injection. That is what makes the override a supported choice rather than a no-op.

## Related

The two modules that currently set `global.prefix` without reading it, `trivy` and `google-gateway`, are cleaned up separately — those lines are dead rather than wrong, since nothing in either module reads the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)