### PR TITLE
trivy, google-gateway: drop the global.prefix that nothing reads

### DIFF
--- a/modules/k8s/google-gateway/agent_input_google.yaml
+++ b/modules/k8s/google-gateway/agent_input_google.yaml
@@ -1,5 +1,4 @@
 global:
-  prefix: "{{ .config.prefix }}"
   internalGateway: "{{ .module.name }}-internal"
   externalGateway: "{{ .module.name }}-external"
 gateways:

--- a/modules/k8s/trivy/agent_input_aws.yaml
+++ b/modules/k8s/trivy/agent_input_aws.yaml
@@ -1,5 +1,4 @@
 global:
-  prefix: "{{ .config.prefix }}"
   aws:
     account: "{{ .toutput.eks.account }}"
     clusterOIDC: "{{ .toutput.eks.oidc_provider }}"

--- a/modules/k8s/trivy/values.yaml
+++ b/modules/k8s/trivy/values.yaml
@@ -1,5 +1,4 @@
 global:
-  prefix: ""
   cloudProvider: ""
   providerConfigRefName: ""
   google:


### PR DESCRIPTION
Both modules set `global.prefix` from `.config.prefix` in their agent input, and neither reads it.

## Why these two and not the others

Overriding `global.prefix` is a legitimate thing to do — it swaps the agent's `<prefix>-<step>-<module>` for the bare environment identifier, which is what you want whenever a name only has to be unique per environment. That is not what these two are doing. They set the key and then never use it, which leaves a pattern lying around for the next person to copy into a module where it *would* change behaviour.

Checked before removing — nothing reads `global.prefix` in either module:

| Checked | trivy | google-gateway |
|---|---|---|
| own `templates/` | none | none |
| `values*.yaml` | only the dead declaration | none |
| vendored chart | `trivy-operator-0.36.0` — zero references | no charts, manifest-only module |
| `.tinput` / `.toptin` from any other module | none anywhere in `modules/` | none anywhere in `modules/` |

`saml-proxy/templates/deployment.yaml:77` is the only consumer of `global.prefix` in the whole repository.

## What changed

- `trivy/agent_input_aws.yaml` — dropped `prefix: "{{ .config.prefix }}"`
- `google-gateway/agent_input_google.yaml` — dropped the same line
- `trivy/values.yaml` — dropped the matching `prefix: ""` declaration, dead for the same reason

The agent still injects `global.prefix` into both `Application`s, as it does for every `argocd-apps` module, so nothing is lost if either module ever needs it.

## Testing

`helm lint --strict` passes on both. Static renders are **byte-identical to main** for both modules.

## Left alone deliberately

`mimir`, `prometheus` and `grafana` also carry a dead `prefix: ""` declaration in `values.yaml` — no template in them reads it either. I did not touch them, since they are outside what this PR was asked to cover. `harbor` and `loki` are untouched as well: their `.config.prefix` uses are live, composing real bucket names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)