### PR TITLE
harbor: write down why the S3 storage is commented out

### DIFF
--- a/modules/k8s/harbor/agent_input_aws.yaml
+++ b/modules/k8s/harbor/agent_input_aws.yaml
@@ -11,6 +11,9 @@ harbor:
       hosts:
         core: "{{ .module.name }}.{{ .toutput.route53.pub_domain }}"
 
+  # S3 storage for the registry. Commented out because Harbor's registry
+  # cannot authenticate to S3 with IRSA yet — see values-aws.yaml for the
+  # reason, the blocking Harbor issues and what to do when it is fixed.
   #persistence:
   #  imageChartStorage:
   #    s3:

--- a/modules/k8s/harbor/templates/aws/mrap.yaml
+++ b/modules/k8s/harbor/templates/aws/mrap.yaml
@@ -1,3 +1,7 @@
+# Activates the crossplane managed resource kinds the S3 setup needs,
+# commented out together with it. Harbor's registry
+# cannot authenticate to S3 with IRSA yet — see values-aws.yaml for the
+# reason, the blocking Harbor issues and what to do when it is fixed.
 # {{- if eq .Values.global.cloudProvider "aws" }}
 # apiVersion: apiextensions.crossplane.io/v1alpha1
 # kind: ManagedResourceActivationPolicy

--- a/modules/k8s/harbor/templates/aws/policy.yaml
+++ b/modules/k8s/harbor/templates/aws/policy.yaml
@@ -1,3 +1,7 @@
+# The IAM policy granting the registry access to its bucket, commented out
+# together with the S3 storage configuration itself. Harbor's registry
+# cannot authenticate to S3 with IRSA yet — see values-aws.yaml for the
+# reason, the blocking Harbor issues and what to do when it is fixed.
 # 
 # {{- if eq .Values.global.cloudProvider "aws" }}
 # 

--- a/modules/k8s/harbor/templates/aws/role.yaml
+++ b/modules/k8s/harbor/templates/aws/role.yaml
@@ -1,3 +1,7 @@
+# The IAM role the registry would assume through IRSA, commented out
+# together with the S3 storage configuration itself. Harbor's registry
+# cannot authenticate to S3 with IRSA yet — see values-aws.yaml for the
+# reason, the blocking Harbor issues and what to do when it is fixed.
 # {{- if eq .Values.global.cloudProvider "aws" }}
 # 
 # apiVersion: iam.aws.upbound.io/v1beta1

--- a/modules/k8s/harbor/templates/aws/rolePolicyAttachment.yaml
+++ b/modules/k8s/harbor/templates/aws/rolePolicyAttachment.yaml
@@ -1,3 +1,7 @@
+# Attaches the bucket policy to the registry role, commented out together
+# with the S3 storage configuration itself. Harbor's registry
+# cannot authenticate to S3 with IRSA yet — see values-aws.yaml for the
+# reason, the blocking Harbor issues and what to do when it is fixed.
 # {{- if eq .Values.global.cloudProvider "aws" }}
 # 
 # apiVersion: iam.aws.upbound.io/v1beta1

--- a/modules/k8s/harbor/templates/aws/s3.yaml
+++ b/modules/k8s/harbor/templates/aws/s3.yaml
@@ -1,3 +1,7 @@
+# The bucket for the registry, commented out together with the S3 storage
+# configuration itself. Harbor's registry cannot authenticate to S3 with IRSA
+# yet — see values-aws.yaml for the reason, the blocking Harbor issues and
+# what to do when it is fixed.
 # {{- if eq .Values.global.cloudProvider "aws" }}
 # 
 # apiVersion: s3.aws.upbound.io/v1beta2

--- a/modules/k8s/harbor/templates/aws/serviceAccount.yaml
+++ b/modules/k8s/harbor/templates/aws/serviceAccount.yaml
@@ -1,3 +1,8 @@
+# The service account the registry would run as, annotated with the IRSA
+# role. Commented out together with the S3 storage configuration itself,
+# because Harbor's registry cannot authenticate to S3 with IRSA yet — see
+# values-aws.yaml for the reason, the blocking Harbor issues and what to do
+# when it is fixed.
 # {{- if eq .Values.global.cloudProvider "aws" }}
 # 
 # apiVersion: v1

--- a/modules/k8s/harbor/values-aws.yaml
+++ b/modules/k8s/harbor/values-aws.yaml
@@ -24,6 +24,45 @@ harbor:
   updateStrategy:
     type: Recreate
 
+  # S3 storage for the registry, commented out and not usable yet.
+  #
+  # Harbor's registry cannot authenticate to S3 with IRSA. Its registry-photon
+  # image is built from distribution v2.8, pinned in Harbor's own Makefile as
+  # REGISTRYVERSION=v2.8.3-patch-redis, and that S3 driver builds a fixed
+  # credential chain of static keys, environment, shared credentials file and
+  # the EC2 instance role. There is no AssumeRoleWithWebIdentity provider in
+  # it, and because the driver always sets credentials explicitly the AWS SDK
+  # never gets to resolve them itself. The service account token is therefore
+  # ignored and the registry silently falls back to the node instance role.
+  #
+  # Turning this on would mean putting static access keys in the registry
+  # configmap, or granting the node role bucket access, and neither is
+  # acceptable. So the registry keeps using the PersistentVolumeClaim from
+  # values.yaml instead.
+  #
+  # Upstream state, checked 2026-09-08 against Harbor 2.15.2:
+  #
+  #   goharbor/harbor#12888  the tracking issue, "Harbor Registry does not
+  #                          support AssumeRoleWithWebIdentity". Open since
+  #                          2020, labelled dependency/upstream/distribution.
+  #   goharbor/harbor#18686  an attempt to patch web identity into Harbor's
+  #                          distribution fork. Closed unmerged, the author
+  #                          called it a hack and pointed at distribution v3.
+  #   goharbor/harbor#21896  "Upgrade to distribution (registry) v3". Open,
+  #                          needs/investigation, no milestone. This is the
+  #                          one to watch.
+  #
+  # distribution v3 already fixes it: it sets static credentials only when
+  # both keys are given and otherwise leaves resolution to the AWS SDK, which
+  # does handle web identity. That shipped in v3.0.0 and is now at v3.1.1, so
+  # the only thing missing is Harbor adopting it.
+  #
+  # To pick this up once a Harbor release ships distribution v3: uncomment the
+  # blocks here and in agent_input_aws.yaml, uncomment the six commented files
+  # under templates/aws/ (s3, role, policy, rolePolicyAttachment,
+  # serviceAccount, mrap — everything there except targetGroupConfiguration),
+  # and leave accesskey and secretkey unset so the SDK picks up the service
+  # account token.
   #persistence:
   #  imageChartStorage:
   #    type: s3


### PR DESCRIPTION
Six files under `harbor/templates/aws/` plus blocks in both AWS value files have been commented out for a long time with nothing recording why. The only way to find out whether it could be switched on was to go and read Harbor's source — so this writes the answer down.

Comments only. No template, value or rendered output changes.

## The finding

**Harbor's registry cannot authenticate to S3 with IRSA, and still cannot as of Harbor 2.15.2** (the version this chart ships, released July 2026).

`registry-photon` is built from distribution v2.8 — pinned in Harbor's own Makefile, and I checked this at the **v2.15.2 tag**, not just `main`:

```
REGISTRYVERSION=v2.8.3-patch-redis
DISTRIBUTION_SRC=https://github.com/goharbor/distribution.git
```

That driver builds a fixed credential chain:

```go
creds := credentials.NewChainCredentials([]credentials.Provider{
    &credentials.StaticProvider{...},          // accesskey / secretkey
    &credentials.EnvProvider{},
    &credentials.SharedCredentialsProvider{},
    &ec2rolecreds.EC2RoleProvider{...},        // EC2 instance profile
})
awsConfig.WithCredentials(creds)
```

No `AssumeRoleWithWebIdentity` provider anywhere in it. And because the driver always sets credentials explicitly, the AWS SDK's own resolution — which does handle web identity — never runs. The service account token is ignored and the registry falls back to the **node instance role**, which is both wrong and a permissions escalation.

goharbor/harbor#12888 reports exactly this behaviour from the outside: *"Instead, the ec2 instance role is used."*

## Blocking issues, recorded in the comment

| Issue | State |
|---|---|
| **goharbor/harbor#12888** | The tracking issue, "Harbor Registry does not support AssumeRoleWithWebIdentity". Open since 2020, labelled `dependency/upstream/distribution` |
| **goharbor/harbor#18686** | Attempt to patch web identity into Harbor's distribution fork. **Closed unmerged** — the author called it "a crazy hack" and pointed at distribution v3 |
| **goharbor/harbor#21896** | "Upgrade to distribution (registry) v3". **Open**, `needs/investigation`, no milestone. The one to watch |

## The upstream fix already exists

distribution v3 rewrote that block to set static credentials only when both keys are supplied, otherwise leaving resolution to the SDK:

```go
if params.AccessKey != "" && params.SecretKey != "" {
    creds := credentials.NewStaticCredentials(...)
    awsConfig.WithCredentials(creds)
}
...
sess, err := session.NewSession(awsConfig)
```

That is native IRSA — no sidecar, no token refresher, no patched configmap. Shipped in v3.0.0, currently at **v3.1.1** (May 2026). The only thing missing is Harbor adopting it, which is #21896.

## Where the comments went

The full explanation lives in **`values-aws.yaml`**, next to the commented `persistence` block — where someone choosing a storage backend will actually look. It covers the mechanism, the three issues, the upstream fix, and a concrete "to pick this up" list.

The other seven places carry a two-to-four line note saying what the file would create and pointing at `values-aws.yaml`, rather than repeating it:

- `agent_input_aws.yaml`
- `templates/aws/{s3,role,policy,rolePolicyAttachment,serviceAccount,mrap}.yaml`

While doing this I found the commented set is **six** template files, not the two I had reported earlier — `role.yaml`, `rolePolicyAttachment.yaml`, `serviceAccount.yaml` and `mrap.yaml` are fully commented too. `targetGroupConfiguration.yaml` is the only live file in that directory. The pick-up list in `values-aws.yaml` names all six.

## Testing

`helm lint --strict` passes. The static render is unchanged — 31 documents before and after, identical resource set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)