### PR TITLE
aws-v2/route53: don't render certificate options for PCA-issued certs

### DIFF
--- a/modules/aws-v2/route53/main.tf
+++ b/modules/aws-v2/route53/main.tf
@@ -184,8 +184,13 @@ resource "aws_acm_certificate" "this" {
   # Use the key algorithm from the domain configuration
   key_algorithm             = each.value.certificate_key_algorithm
 
-  options {
-    export = each.value.certificate_authority_arn != "" ? "ENABLED" : each.value.certificate_export
+  # options is rejected by the ACM API for private certs;
+  # PCA-issued certs are always exportable anyway
+  dynamic "options" {
+    for_each = each.value.certificate_authority_arn == "" ? [1] : []
+    content {
+      export = each.value.certificate_export
+    }
   }
   
   lifecycle {


### PR DESCRIPTION
## Problem

`aws_acm_certificate.this` rendered the `options` block for every certificate, including PCA-issued (`PRIVATE`) ones:

```hcl
options {
  export = each.value.certificate_authority_arn != "" ? "ENABLED" : each.value.certificate_export
}
```

`options` is the parameter used to specify certificate transparency logging, which is public-only, and PCA-issued certificates are always exportable — so the ACM API rejects `CertificateOptions` for `PRIVATE` certificates.

This is the same root cause as the earlier failure on `UpdateCertificateOptions`. It now fails at `RequestCertificate` instead, because `create_before_destroy` replaces the certificate rather than modifying it. The plan still showed the block being rendered for `this["private"]` with `certificate_transparency_logging_preference = ENABLED` and `export = ENABLED`.

## Fix

Make `options` a `dynamic` block emitted only when `certificate_authority_arn == ""` (public certs). For PCA-issued certs no `options` is rendered at all, so the provider omits `CertificateOptions` from `RequestCertificate` and the `ValidationException` goes away.

Public certificates keep the existing behaviour: `export` comes from `certificate_export` (default `DISABLED`).

## Notes

- Only the `options` block changed; nothing else in the module was touched (the file has pre-existing `tofu fmt` alignment drift that this PR deliberately leaves alone to keep the diff reviewable).
- `tofu validate` passes (OpenTofu 1.12.6); `tofu fmt` reports no issues on the new block.