### PR TITLE
nuke: keep the maintainer user's second access key

### DIFF
--- a/modules/aws/aws-nuke-config.yml
+++ b/modules/aws/aws-nuke-config.yml
@@ -145,6 +145,7 @@ accounts:
       - "github -> AKIA4YTQYUGC4RTLXD6W"
       - "github -> AKIA4YTQYUGCUQMU3R4L"
       - "maintainer -> AKIA4YTQYUGCXECEMVON"
+      - "maintainer -> AKIA4YTQYUGC7QHRLMAL"
       - "contributor -> AKIA4YTQYUGCXBN2REI6"
       EC2TGW:
       - "tgw-092384f97967bfffe"


### PR DESCRIPTION
## Problem

The `maintainer` IAM user now has a second access key, used for interactive `kubectl`/`aws` access to the `biz-infra-eks` and `pri-infra-eks` test clusters. Only the first key was listed under `IAMUserAccessKey`, so the nightly nuke run would delete the new one.

The existing `maintainer` entry is left alone — it's a different key (CI's `MAINTAINER_AWS_ACCESS_KEY_ID`), and the user holds both. `github` already had two keys listed, so multiple entries per user is the established pattern here.

Config still parses as valid YAML and the filter list reads back with all five entries.

## Timing

`nuke.yaml` runs on `cron: "0 16 * * *"`, so this needs to be on `main` before 16:00 UTC today or the key goes with tonight's run.

## Follow-up worth considering

aws-nuke supports property filters, so this list could become `{property: UserName, value: maintainer}` and cover every key the user holds — no literal key IDs in the repo, and no config change on rotation. That also matters because GitHub push protection rescans the whole blob on any edit to this file: all five pre-existing key IDs had to be allowlisted to land this one-line change. Left out of this PR to keep tonight's run low-risk; the property name should be verified against aws-nuke v3.48.2 first.