### PR TITLE
agent_stable: name the k8s job for what it does

### DIFF
--- a/.github/workflows/agent_stable.yaml
+++ b/.github/workflows/agent_stable.yaml
@@ -97,7 +97,7 @@ jobs:
     concurrency:
       group: pr-modules-test
       cancel-in-progress: false
-    name: Release
+    name: Install and test stable K8s
     steps:
     - name: Free disk space
       run: |


### PR DESCRIPTION
The `testk8s` job in `agent_stable.yaml` carried `name: Release`, but Agent Stable does not release anything — the job installs `modules/k8s` and runs its tests against AWS and Google simultaneously (`./stable.sh k8s`, with both sets of cloud credentials).

The effect was that a k8s test failure appeared in the Actions UI, and in `gh run view`, as a failed job called "Release". That reads as a release/publishing problem rather than a k8s module test failure.

Renamed to `Install and test stable K8s`, which matches the sibling jobs (`Install stable AWS`, `Install stable Google`) and the Slack text the job already posts (`Fresh installation of latest release failed for K8s`).

No behaviour change — only the display name. Agent Stable runs on `schedule`/`workflow_dispatch` and its job names are not used as required status checks, so nothing depends on the old name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)