### PR TITLE
workflows: drop the empty version from Slack failure messages

### DIFF
--- a/.github/workflows/aws_main.yml
+++ b/.github/workflows/aws_main.yml
@@ -149,7 +149,7 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_COLOR: 'failure'
-        SLACK_MESSAGE: 'Failed to update modules/aws-${{ steps.get_latest_release.outputs.new_version }}-rc${{ github.run_number }} on main'
+        SLACK_MESSAGE: 'Failed to update modules/aws on main (run #${{ github.run_number }})'
         SLACK_USERNAME: ${{ secrets.SLACK_USERNAME }}
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_ICON_EMOJI: ${{ secrets.SLACK_ICON_EMOJI }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -105,7 +105,7 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_COLOR: 'failure'
-        SLACK_MESSAGE: 'Failed to build ${{ inputs.name }}-${{ steps.get_latest_release.outputs.new_version }}-rc${{ github.run_number }}'
+        SLACK_MESSAGE: 'Failed to build ${{ inputs.name }} (run #${{ github.run_number }})'
         SLACK_USERNAME: ${{ secrets.SLACK_USERNAME }}
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_ICON_EMOJI: ${{ secrets.SLACK_ICON_EMOJI }}

--- a/.github/workflows/google_main.yml
+++ b/.github/workflows/google_main.yml
@@ -150,7 +150,7 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_COLOR: 'failure'
-        SLACK_MESSAGE: 'Failed to update modules/google-${{ steps.get_latest_release.outputs.new_version }}-rc${{ github.run_number }} on main'
+        SLACK_MESSAGE: 'Failed to update modules/google on main (run #${{ github.run_number }})'
         SLACK_USERNAME: ${{ secrets.SLACK_USERNAME }}
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_ICON_EMOJI: ${{ secrets.SLACK_ICON_EMOJI }}

--- a/.github/workflows/k8s_main.yml
+++ b/.github/workflows/k8s_main.yml
@@ -169,7 +169,7 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_COLOR: 'failure'
-        SLACK_MESSAGE: 'Failed to update modules/k8s-${{ steps.get_latest_release.outputs.new_version }}-rc${{ github.run_number }} on main'
+        SLACK_MESSAGE: 'Failed to update modules/k8s on main (run #${{ github.run_number }})'
         SLACK_USERNAME: ${{ secrets.SLACK_USERNAME }}
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_ICON_EMOJI: ${{ secrets.SLACK_ICON_EMOJI }}

--- a/.github/workflows/providers_main.yml
+++ b/.github/workflows/providers_main.yml
@@ -80,7 +80,7 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_COLOR: 'failure'
-        SLACK_MESSAGE: 'Failed to update providers-${{ steps.get_latest_release.outputs.new_version }}-rc${{ github.run_number }} on main'
+        SLACK_MESSAGE: 'Failed to update providers on main (run #${{ github.run_number }})'
         SLACK_USERNAME: ${{ secrets.SLACK_USERNAME }}
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_ICON_EMOJI: ${{ secrets.SLACK_ICON_EMOJI }}


### PR DESCRIPTION
Slack failure notifications interpolated `steps.get_latest_release.outputs.new_version`, but `Get latest release` runs *after* the tests and the build. When those fail — which is the only reason the failure message is sent — the output is unset and the version renders empty.

Real examples from the alerts channel:

```
Failed to update modules/aws--rc185 on main
```

Note the empty version and the doubled hyphen. In `aws_main.yml` the ordering is explicit: `Run tests` is step 3, `Get latest release` is step 8, and the failure notify reads an output that step never produced.

Changed the five affected messages to report the module or image plus the run number, both of which are always available on the failure path:

| Before | After |
| --- | --- |
| `Failed to update modules/aws-<empty>-rc185 on main` | `Failed to update modules/aws on main (run #185)` |
| `Failed to build entigo-infralib-test-<empty>-rc372` | `Failed to build entigo-infralib-test (run #372)` |

Files: `aws_main.yml`, `google_main.yml`, `k8s_main.yml`, `providers_main.yml`, `build-images.yaml`.

The success messages are untouched — they run after `Get latest release` has populated the version, so they are correct as they stand. `rtCamp/action-slack-notify` already attaches the commit and Actions URL to every message, so the run remains directly linkable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)