### PR TITLE
agent_release: report k8s failures from the job that runs the tests

### DIFF
--- a/.github/workflows/agent_release.yaml
+++ b/.github/workflows/agent_release.yaml
@@ -70,17 +70,6 @@ jobs:
         SLACK_ICON_EMOJI: ${{ secrets.SLACK_ICON_EMOJI }}
         SLACK_FOOTER: ""
   
-    - name: Slack Failed To Install Latest Release Message
-      if: ${{ failure() }}
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_COLOR: 'failure'
-        SLACK_MESSAGE: 'Updating from latest release to main failed for K8S.'
-        SLACK_USERNAME: ${{ secrets.SLACK_USERNAME }}
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_ICON_EMOJI: ${{ secrets.SLACK_ICON_EMOJI }}
-        SLACK_FOOTER: ""
-        
   release:   
     runs-on: ubuntu-latest
     needs: [install_main_aws,install_main_google]
@@ -641,8 +630,18 @@ jobs:
         SLACK_ICON_EMOJI: ${{ secrets.SLACK_ICON_EMOJI }}
         MSG_MINIMAL: actions url,commit
         SLACK_FOOTER: ""
+    - name: Slack Failed K8s Tests Message
+      if: ${{ failure() && steps.k8s_tests.outcome == 'failure' }}
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_COLOR: 'failure'
+        SLACK_MESSAGE: 'Updating from latest release to main failed for K8S.'
+        SLACK_USERNAME: ${{ secrets.SLACK_USERNAME }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_ICON_EMOJI: ${{ secrets.SLACK_ICON_EMOJI }}
+        SLACK_FOOTER: ""
     - name: Slack Failed To Release Message
-      if: ${{ failure() }}
+      if: ${{ failure() && steps.k8s_tests.outcome != 'failure' }}
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_COLOR: 'failure'


### PR DESCRIPTION
Agent Release reported k8s status from the wrong place, in both directions.

**False K8s alerts.** The `install_main_google` job had *two* `if: ${{ failure() }}` notification steps — one for Google and one saying `Updating from latest release to main failed for K8S.` That job only runs `./release.sh tf` for Google, so any Google failure posted both messages and the K8s claim was never true. The alerts channel bears this out: `... failed for Google.` appears 5 times and `... failed for K8S.` appears 5 times, exactly paired.

**Real k8s failures reported as release failures.** The k8s modules are installed and tested in the `release` job, by its `Run k8s tests` step (`id: k8s_tests`, `./release.sh k8s`), which runs against both clouds before any publishing happens. That job had a single `failure()` notification reading `Releasing of new version failed.`, so a k8s module test failure was announced as a problem with cutting the release.

## Changes

- Remove the misplaced K8S notification from `install_main_google`.
- Split the `release` job's failure notification on `steps.k8s_tests.outcome`:
  - `failure() && steps.k8s_tests.outcome == 'failure'` → `Updating from latest release to main failed for K8S.`
  - `failure() && steps.k8s_tests.outcome != 'failure'` → `Releasing of new version failed.`

Both existing message strings are kept verbatim, so nothing that reads the channel needs to learn new text.

If the job fails before `k8s_tests` runs — for example in `Free disk space` or `Checkout code` — `outcome` is unset, the `!=` branch matches, and it reports as a release failure. That is the intended fallback: a failure that never reached the k8s step is not a k8s failure.

Net effect: `failed for K8S.` now appears only when the k8s tests actually failed, and it becomes possible to tell a k8s regression apart from a publishing problem in Agent Release for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)