### PR TITLE
[Merge first] platform-apis: pass the KMS ARNs as optional agent outputs

### DIFF
--- a/modules/k8s/platform-apis/agent_input.yaml
+++ b/modules/k8s/platform-apis/agent_input.yaml
@@ -1,3 +1,12 @@
+global:
+  # Empty where the environment has no KMS module. platform-apis guards every KMS
+  # reference in its EnvironmentConfigs on these, the same way crossplane-aws guards
+  # the KMS observers themselves.
+  kms:
+    dataKeyArn: "{{ .toptout.kms.data_key_arn }}"
+    configKeyArn: "{{ .toptout.kms.config_key_arn }}"
+    dataAliasArn: "{{ .toptout.kms.data_alias_arn }}"
+
 platform-apis:
   zone:
     kyvernoNamespace: "{{ .tmodule.kyverno }}"


### PR DESCRIPTION
Companion to **entigolabs/platform-apis#213** (Phase 1 of 4). These two must roll out together.

platform-apis hardcoded `dataKMSKey: data`, `configKMSKey: config` and `dataKMSAlias: data` in its own chart defaults, so an environment with no KMS module — `pri`, deliberately — still advertised those keys in every `EnvironmentConfig`, and the compositions then failed trying to fetch them.

`platform-apis#213` guards each of those fields on a matching ARN in `global.kms`. This supplies them:

```yaml
global:
  kms:
    dataKeyArn: "{{ .toptout.kms.data_key_arn }}"
    configKeyArn: "{{ .toptout.kms.config_key_arn }}"
    dataAliasArn: "{{ .toptout.kms.data_alias_arn }}"
```

`.toptout` yields an empty string when the output does not exist, and that emptiness is the entire signal. These are the same three outputs `modules/k8s/crossplane-aws/agent_input_aws.yaml` already consumes to decide whether to create the KMS observers, so the same source now drives both creating an observer and referencing it — they cannot drift.

Top-level `global:` because Helm propagates it to the `platform-apis` subchart, matching how `crossplane-aws` structures its own agent input.

## Why the two must land together

`platform-apis#213` defaults `global.kms.*` to empty. Without this PR, an environment that genuinely has KMS would stop referencing its keys — and since Phase 2 has not landed, the requirement is still declared unconditionally and would be asked to fetch a key named `""`.

With both in place, an environment with a KMS module behaves exactly as it does today; `pri` gets a truthful `EnvironmentConfig` and is unblocked once Phase 2 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)