### PR TITLE
images: stop main and PR image builds cancelling each other

### DIFF
--- a/.github/workflows/images_aws.yml
+++ b/.github/workflows/images_aws.yml
@@ -17,8 +17,16 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by the branch the cascade started from. On a workflow_run event
+  # github.ref is always the default branch, so a PR's cascade and main's
+  # cascade shared one group and cancelled each other; head_branch carries the
+  # parent run's real branch. head_ref covers direct PR runs, so a PR's direct
+  # build and its cascaded build serialise instead of racing on the same tag.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+  # Superseding an earlier run is right when a PR gets a new push, but a
+  # workflow_run run is the only build triggered by its parent, so cancelling
+  # it just loses an image. Those queue instead.
+  cancel-in-progress: ${{ github.event_name != 'workflow_run' }}
 
 jobs:
   build:

--- a/.github/workflows/images_google.yml
+++ b/.github/workflows/images_google.yml
@@ -17,8 +17,16 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by the branch the cascade started from. On a workflow_run event
+  # github.ref is always the default branch, so a PR's cascade and main's
+  # cascade shared one group and cancelled each other; head_branch carries the
+  # parent run's real branch. head_ref covers direct PR runs, so a PR's direct
+  # build and its cascaded build serialise instead of racing on the same tag.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+  # Superseding an earlier run is right when a PR gets a new push, but a
+  # workflow_run run is the only build triggered by its parent, so cancelling
+  # it just loses an image. Those queue instead.
+  cancel-in-progress: ${{ github.event_name != 'workflow_run' }}
 
 jobs:
   build:

--- a/.github/workflows/images_kubectl.yaml
+++ b/.github/workflows/images_kubectl.yaml
@@ -17,8 +17,16 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by the branch the cascade started from. On a workflow_run event
+  # github.ref is always the default branch, so a PR's cascade and main's
+  # cascade shared one group and cancelled each other; head_branch carries the
+  # parent run's real branch. head_ref covers direct PR runs, so a PR's direct
+  # build and its cascaded build serialise instead of racing on the same tag.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+  # Superseding an earlier run is right when a PR gets a new push, but a
+  # workflow_run run is the only build triggered by its parent, so cancelling
+  # it just loses an image. Those queue instead.
+  cancel-in-progress: ${{ github.event_name != 'workflow_run' }}
 
 jobs:
   build:

--- a/.github/workflows/images_test.yml
+++ b/.github/workflows/images_test.yml
@@ -17,8 +17,16 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by the branch the cascade started from. On a workflow_run event
+  # github.ref is always the default branch, so a PR's cascade and main's
+  # cascade shared one group and cancelled each other; head_branch carries the
+  # parent run's real branch. head_ref covers direct PR runs, so a PR's direct
+  # build and its cascaded build serialise instead of racing on the same tag.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
+  # Superseding an earlier run is right when a PR gets a new push, but a
+  # workflow_run run is the only build triggered by its parent, so cancelling
+  # it just loses an image. Those queue instead.
+  cancel-in-progress: ${{ github.event_name != 'workflow_run' }}
 
 jobs:
   build:

--- a/.github/workflows/images_tools.yaml
+++ b/.github/workflows/images_tools.yaml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Split out of #1723, which deliberately left this alone. Independent of it — the two branches merge cleanly in either order (verified), and neither depends on the other.

## Problem

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

On a `workflow_run` event `github.ref` is **always the default branch**, regardless of which branch actually started the cascade. So every cascaded build for a given workflow landed in one single group, and `cancel-in-progress: true` made them kill each other. There are `cancelled` runs in the history from exactly this — e.g. two on 2026-08-31 and 2026-09-03 in `Build images/test`.

Concretely, for `Build images/google` all four of these shared the group `Build images/google-refs/heads/main`:

| run | group before |
|---|---|
| PR on `oracle`, direct | `…-refs/heads/main` |
| push to main, direct | `…-refs/heads/main` |
| cascade ← tools PR on `oracle` | `…-refs/heads/main` |
| cascade ← tools push to main | `…-refs/heads/main` |

Push to main while a PR's cascade is in flight and one of them silently disappears.

## Fix

Group by the branch the cascade **started from**:

```yaml
group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
cancel-in-progress: ${{ github.event_name != 'workflow_run' }}
```

- `github.event.workflow_run.head_branch` is the parent run's branch — the PR source branch when a PR started the cascade, `main` when a push did. This is what separates the two colliding cases.
- `github.head_ref` catches direct PR runs, so a PR's *direct* build and its *cascaded* build share a group and serialise instead of racing to push the same `dev` tag.
- `github.ref_name` keeps push runs on a plain branch name (`main`, not `refs/heads/main`) so all three forms compare equal.
- `cancel-in-progress` now excludes cascaded runs. Superseding an earlier run is right when a PR gets a new push, but a `workflow_run` run is the only build its parent triggers — cancelling it loses an image with nothing queued to replace it.

`images/tools` has no `workflow_run` trigger, so it only gets the group normalised to the same branch-name form its dependents use; its `cancel-in-progress: true` is unchanged.

## Result

| run | group after | cancel |
|---|---|---|
| PR on `oracle`, direct | `Build images/google-oracle` | true |
| cascade ← tools PR on `oracle` | `Build images/google-oracle` | false |
| push to main, direct | `Build images/google-main` | true |
| cascade ← tools push to main | `Build images/google-main` | false |

The PR cascade and the main cascade are now in **entirely separate groups**, which is the bug. What remains grouped is intra-branch, which is the intent: same branch serialises, different branches run independently.

Within `Build images/google-oracle` the direct run can still cancel the cascaded one, and that is correct — the direct run is triggered by the PR event itself so it always starts first and the cascade queues behind it; it only cancels if a *new* push arrives to the PR branch, in which case a fresh cascade follows anyway.

## Known limits

- **Hop 2 is still coarse.** `test` is reached via `google`, and a `workflow_run`-triggered parent reports `head_branch` as `main`, so all cascaded `test` runs share `Build images/test-main` whatever started them. Same root cause as the tag problem in #1723 — but harmless here, because with `cancel-in-progress: false` they queue rather than cancel, so no build is lost. It cannot be fixed the way #1723 fixes the tag: `concurrency` is evaluated before any job runs, so there is nothing to read a parent's recorded value with.
- **GitHub keeps only one pending run per group.** If three cascades pile up on one group, the middle (pending) one is dropped. Much better than today's "newest cancels whatever is running", but not a queue of unbounded depth.

## Testing

Static change, so I evaluated both expressions against the context values each trigger actually produces (taken from real run objects: `pull_request` runs carry the source branch in `head_branch`, `workflow_run` runs carry `main`) across the six scenarios in the tables above, confirming the before-state collides on two groups and the after-state does not. YAML parses on all five workflows.

As with #1723, the real cascade can only be exercised once this is on `main`, since `workflow_run` always uses the default branch's copy of the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
